### PR TITLE
feat: add /aiwg-kb command and troubleshooting documentation

### DIFF
--- a/agentic/code/frameworks/sdlc-complete/commands/aiwg-kb.md
+++ b/agentic/code/frameworks/sdlc-complete/commands/aiwg-kb.md
@@ -1,0 +1,207 @@
+---
+description: Search AIWG knowledge base for help, documentation, and troubleshooting
+category: sdlc-help
+argument-hint: "<topic>"
+allowed-tools: Read, Glob, Grep
+model: haiku
+---
+
+# AIWG Knowledge Base
+
+You are an AIWG documentation assistant. Help users find information about the AI Writing Guide framework.
+
+## Your Task
+
+When invoked with `/aiwg-kb "<topic>"`:
+
+1. **Interpret** the user's query to understand what they need
+2. **Search** relevant AIWG documentation
+3. **Provide** clear, actionable answers with references
+
+## Topic Categories
+
+Map user queries to documentation areas:
+
+| Query Pattern | Documentation Area | Path |
+|---------------|-------------------|------|
+| "setup", "install", "installation" | Setup troubleshooting | `docs/troubleshooting/setup-issues.md` |
+| "agent", "command", "not found", "deploy" | Deployment issues | `docs/troubleshooting/deployment-issues.md` |
+| "template", "path", "directory", "aiwg_root" | Path issues | `docs/troubleshooting/path-issues.md` |
+| "claude", "factory", "warp", "platform" | Platform issues | `docs/troubleshooting/platform-issues.md` |
+| "quickstart", "getting started", "how to start" | Quickstart guides | `docs/quickstart.md`, `docs/quickstart-sdlc.md`, `docs/quickstart-mmk.md` |
+| "sdlc", "lifecycle", "phase", "inception", "elaboration" | SDLC framework | `agentic/code/frameworks/sdlc-complete/README.md` |
+| "marketing", "mmk", "campaign" | Marketing framework | `agentic/code/frameworks/media-marketing-kit/README.md` |
+| "natural language", "commands", "what can I say" | Natural language guide | `agentic/code/frameworks/sdlc-complete/docs/simple-language-translations.md` |
+| "troubleshooting", "help", "problem", "error", "fix" | Troubleshooting index | `docs/troubleshooting/index.md` |
+
+## Execution Steps
+
+### Step 1: Resolve AIWG Path
+
+```bash
+AIWG_PATH="${AIWG_ROOT:-$HOME/.local/share/ai-writing-guide}"
+```
+
+### Step 2: Interpret Query
+
+Parse the user's topic to identify:
+- Primary subject (setup, deployment, platform, workflow, etc.)
+- Specific issue if mentioned (error message, symptom)
+- Platform context if relevant (Claude, Factory, Warp)
+
+### Step 3: Retrieve Documentation
+
+Use Read tool to fetch relevant documentation based on topic mapping.
+
+**Priority order**:
+1. Troubleshooting docs (if issue/error/problem indicated)
+2. Quickstart guides (if "how to" or getting started)
+3. Framework README (if framework-specific)
+4. Natural language guide (if command-related)
+
+### Step 4: Provide Answer
+
+Format response as:
+
+```markdown
+## {Topic}
+
+{Concise answer to the query}
+
+### Quick Fix
+
+{Most common solution - 1-3 steps}
+
+### Details
+
+{Additional context if needed}
+
+### Related Topics
+
+- [Topic 1](path) - Brief description
+- [Topic 2](path) - Brief description
+
+---
+*Source: {path to documentation}*
+*Use `/aiwg-kb "<related-topic>"` for more help*
+```
+
+## Natural Language Handling
+
+Users may ask questions naturally. Map to topics:
+
+| User Says | Topic |
+|-----------|-------|
+| "How do I fix my AIWG install?" | setup issues |
+| "Why can't Claude find my agents?" | deployment issues |
+| "Template not found error" | path issues |
+| "How do I start a new project?" | quickstart |
+| "What commands can I use?" | natural language |
+| "Factory droids not working" | platform issues (factory) |
+| "Help with AIWG" | troubleshooting index |
+
+## Example Responses
+
+### Example 1: Setup Issue
+
+```
+User: /aiwg-kb "installation not working"
+
+Response:
+## Installation Issues
+
+AIWG installation problems usually stem from PATH or permission issues.
+
+### Quick Fix
+
+```bash
+# Reinstall AIWG
+aiwg -reinstall
+
+# Reload shell
+source ~/.bash_aliases
+```
+
+### If That Doesn't Work
+
+1. Check installation exists: `ls ~/.local/share/ai-writing-guide/`
+2. Verify alias: `alias aiwg`
+3. Manual install if needed - see setup guide
+
+### Related Topics
+
+- [Path Issues](docs/troubleshooting/path-issues.md)
+- [Deployment Issues](docs/troubleshooting/deployment-issues.md)
+
+---
+*Source: docs/troubleshooting/setup-issues.md*
+```
+
+### Example 2: Natural Language Question
+
+```
+User: /aiwg-kb "what can I say to Claude?"
+
+Response:
+## Natural Language Commands
+
+You can use natural language to trigger AIWG workflows. No need to memorize slash commands!
+
+### Common Phrases
+
+**Phase Transitions**:
+- "Transition to Elaboration"
+- "Move to Construction"
+- "Start Inception"
+
+**Reviews**:
+- "Run security review"
+- "Execute tests"
+- "Check compliance"
+
+**Status**:
+- "Where are we?"
+- "Can we transition?"
+- "Project status"
+
+### Full Reference
+
+See the complete natural language guide for 70+ supported phrases.
+
+### Related Topics
+
+- [SDLC Framework](agentic/code/frameworks/sdlc-complete/README.md)
+- [Quickstart Guide](docs/quickstart-sdlc.md)
+
+---
+*Source: agentic/code/frameworks/sdlc-complete/docs/simple-language-translations.md*
+```
+
+## Error Handling
+
+If topic not recognized:
+
+```markdown
+## Help with AIWG
+
+I wasn't sure what "{topic}" refers to. Here are common help topics:
+
+- **Setup issues**: Installation, PATH, permissions
+- **Deployment issues**: Agents not found, commands missing
+- **Path issues**: Templates, directories, AIWG_ROOT
+- **Platform issues**: Claude Code, Factory AI, Warp Terminal
+- **Getting started**: Quickstart guides for SDLC or Marketing
+
+Try: `/aiwg-kb "setup"` or `/aiwg-kb "quickstart"`
+
+Or ask naturally: "How do I fix my AIWG install?"
+```
+
+## Success Criteria
+
+- [ ] Query interpreted correctly
+- [ ] Relevant documentation retrieved
+- [ ] Clear, actionable answer provided
+- [ ] Quick fix included for troubleshooting queries
+- [ ] Related topics referenced
+- [ ] Source documentation cited

--- a/agentic/code/frameworks/sdlc-complete/commands/aiwg-setup-project.md
+++ b/agentic/code/frameworks/sdlc-complete/commands/aiwg-setup-project.md
@@ -406,37 +406,25 @@ See `{AIWG_PATH}/docs/simple-language-translations.md` for complete phrase list.
 - **Orchestrator Docs**: {AIWG_PATH}/docs/orchestrator-architecture.md
 - **Multi-Agent Pattern**: {AIWG_PATH}/docs/multi-agent-documentation-pattern.md
 
-## Troubleshooting
+## Need Help?
 
-> **Note**: The tips below are for reference if you encounter issues in the future. If setup completed successfully, no action is needed.
+If you encounter any issues, use the AIWG knowledge base:
 
-**Template Not Found**:
-```bash
-# Verify AIWG installation
-ls {AIWG_PATH}/agentic/code/frameworks/sdlc-complete/templates/
+```text
+# Slash command
+/aiwg-kb "setup issues"
+/aiwg-kb "agent not found"
+/aiwg-kb "template errors"
 
-# If missing, reinstall AIWG
-aiwg -reinstall
+# Or ask naturally
+"How do I fix my AIWG install?"
+"Why aren't my agents working?"
+"Help with AIWG templates"
 ```
 
-**Agent Access Denied**:
-- Check `.claude/settings.json` has read access to AIWG installation path
-- Add permission: `"Read({AIWG_PATH}/**)"`
+**Common topics**: setup issues, deployment issues, path issues, platform issues
 
-**Commands Not Found**:
-```bash
-# Deploy commands to project
-aiwg -deploy-commands --mode sdlc
-
-# Verify deployment
-ls .claude/commands/flow-*.md
-```
-
-**Need to Update CLAUDE.md Again**:
-```bash
-# Safe to run multiple times - preserves user content
-/aiwg-setup-project
-```
+**Quick reference**: {AIWG_PATH}/docs/troubleshooting/
 ```
 
 ## Implementation Notes
@@ -485,7 +473,7 @@ When merging AIWG section, ensure these are included:
 8. ✅ **Phase Overview** - Inception → Elaboration → Construction → Transition → Production
 9. ✅ **Quick Start Guide** - Step-by-step initialization
 10. ✅ **Common Patterns** - Example workflows (risk, architecture, security, testing)
-11. ✅ **Troubleshooting** - Common issues and solutions
+11. ✅ **Need Help** - Reference to /aiwg-kb and troubleshooting docs
 
 **Reference**: Template at `{AIWG_ROOT}/agentic/code/frameworks/sdlc-complete/templates/project/CLAUDE.md`
 

--- a/agentic/code/frameworks/sdlc-complete/docs/simple-language-translations.md
+++ b/agentic/code/frameworks/sdlc-complete/docs/simple-language-translations.md
@@ -257,6 +257,21 @@ Next Steps:
 | "Validate {technical-risk}" | Same as above | `build-poc` |
 | "Spike {feature}" | Same as above | `build-poc` |
 
+### Help and Troubleshooting
+
+| User Says | Intent | Action |
+|-----------|--------|--------|
+| "Help with AIWG" | General help | `aiwg-kb "help"` |
+| "How do I fix {issue}?" | Troubleshooting | `aiwg-kb "{issue}"` |
+| "AIWG not working" | Setup troubleshooting | `aiwg-kb "setup issues"` |
+| "Agent not found" | Deployment troubleshooting | `aiwg-kb "deployment issues"` |
+| "Template not found" | Path troubleshooting | `aiwg-kb "path issues"` |
+| "Why can't Claude find {x}?" | Troubleshooting | `aiwg-kb "deployment issues"` |
+| "{Platform} not working" | Platform troubleshooting | `aiwg-kb "platform issues"` |
+| "What commands can I use?" | Natural language reference | `aiwg-kb "natural language"` |
+| "How do I start?" | Quickstart | `aiwg-kb "quickstart"` |
+| "AIWG documentation" | Documentation | `aiwg-kb "help"` |
+
 ## Regex Patterns (For Implementation)
 
 If implementing pattern matching, use these regex patterns:
@@ -277,6 +292,15 @@ WORKFLOWS = {
 STATUS = {
     r"(where|what).*(are we|next|status)": "project-status",
     r"(can|ready).*(transition|move|proceed)": "flow-gate-check",
+}
+
+HELP = {
+    r"(help|fix|problem|issue|error).*(aiwg|install|setup)": "aiwg-kb setup",
+    r"(agent|command).*(not found|missing|can't find)": "aiwg-kb deployment",
+    r"(template|path|directory).*(not found|missing|error)": "aiwg-kb path",
+    r"(claude|factory|warp).*(not working|issue|problem)": "aiwg-kb platform",
+    r"(how|what).*(start|begin|commands?)": "aiwg-kb quickstart",
+    r"(help|documentation|docs).*aiwg": "aiwg-kb help",
 }
 ```
 

--- a/docs/troubleshooting/deployment-issues.md
+++ b/docs/troubleshooting/deployment-issues.md
@@ -1,0 +1,122 @@
+# Deployment Issues
+
+Problems with agent and command deployment.
+
+## Agents Not Found
+
+**Symptoms**: "Agent not found", subagent calls fail, Task tool errors.
+
+**Cause**: Agents not deployed to project.
+
+**Solution**:
+
+```bash
+# Deploy agents
+aiwg -deploy-agents --mode sdlc
+
+# Verify deployment
+ls .claude/agents/
+
+# Should show 50+ agent files
+```
+
+## Commands Not Found
+
+**Symptoms**: Slash commands not recognized, "/command not found".
+
+**Cause**: Commands not deployed to project.
+
+**Solution**:
+
+```bash
+# Deploy commands
+aiwg -deploy-commands --mode sdlc
+
+# Verify deployment
+ls .claude/commands/
+
+# Should show flow-*.md and other command files
+```
+
+## Agent Access Denied
+
+**Symptoms**: "Permission denied" when agent tries to read AIWG files.
+
+**Cause**: Claude Code settings missing read permission for AIWG installation.
+
+**Solution**:
+
+1. Open `.claude/settings.local.json` (or create it)
+2. Add read permission:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read(/home/YOUR_USER/.local/share/ai-writing-guide/**)"
+    ]
+  }
+}
+```
+
+Replace `YOUR_USER` with your actual username.
+
+## Outdated Agents
+
+**Symptoms**: Agents missing new features, old behavior.
+
+**Cause**: Project has old agent versions.
+
+**Solution**:
+
+```bash
+# Update AIWG installation first
+aiwg -update
+
+# Force redeploy agents
+aiwg -deploy-agents --mode sdlc --force
+aiwg -deploy-commands --mode sdlc
+```
+
+## Factory AI Droids Not Loading
+
+**Symptoms**: Droids not appearing in Factory `/droids` menu.
+
+**Cause**: Factory requires manual import after deployment.
+
+**Solution**:
+
+```bash
+# In Factory CLI
+droid .
+/droids
+# Press 'I' to import
+# Press 'A' to select all
+# Press Enter to confirm
+```
+
+See [Factory Quickstart](../integrations/factory-quickstart.md) for details.
+
+## Warp Not Loading WARP.md
+
+**Symptoms**: Warp AI doesn't recognize AIWG commands/context.
+
+**Cause**: WARP.md not in project root or Warp not reindexed.
+
+**Solution**:
+
+```bash
+# Verify WARP.md exists
+ls WARP.md
+
+# If missing, deploy
+aiwg -deploy-agents --platform warp --mode sdlc
+
+# In Warp, reindex
+/init
+```
+
+## Related
+
+- [Setup Issues](setup-issues.md) - Installation problems
+- [Platform Issues](platform-issues.md) - Platform-specific problems

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -1,0 +1,55 @@
+# AIWG Troubleshooting Guide
+
+Quick solutions for common issues with the AI Writing Guide framework.
+
+## Topics
+
+| Issue | Guide |
+|-------|-------|
+| Installation problems | [Setup Issues](setup-issues.md) |
+| Agent/command not found | [Deployment Issues](deployment-issues.md) |
+| Template or path errors | [Path Issues](path-issues.md) |
+| Platform integration | [Platform Issues](platform-issues.md) |
+
+## Quick Help
+
+Use the `/aiwg-kb` command or natural language to get help:
+
+```text
+/aiwg-kb "setup issues"
+/aiwg-kb "agent not found"
+
+# Or natural language
+"How do I fix my AIWG install?"
+"Why can't Claude find my agents?"
+"Help with AIWG templates"
+```
+
+## Common Quick Fixes
+
+### Reinstall AIWG
+
+```bash
+aiwg -reinstall
+```
+
+### Redeploy Agents
+
+```bash
+aiwg -deploy-agents --mode sdlc --force
+aiwg -deploy-commands --mode sdlc
+```
+
+### Update Platform Integration
+
+```text
+# In Claude Code
+/aiwg-update-claude
+```
+
+### Verify Installation
+
+```bash
+aiwg -version
+ls ~/.local/share/ai-writing-guide/
+```

--- a/docs/troubleshooting/path-issues.md
+++ b/docs/troubleshooting/path-issues.md
@@ -1,0 +1,107 @@
+# Path Issues
+
+Problems with templates, files, and directory paths.
+
+## Template Not Found
+
+**Symptoms**: "Template not found", errors referencing template paths.
+
+**Cause**: AIWG installation incomplete or path resolution failed.
+
+**Solution**:
+
+```bash
+# Verify templates exist
+ls ~/.local/share/ai-writing-guide/agentic/code/frameworks/sdlc-complete/templates/
+
+# If missing, reinstall
+aiwg -reinstall
+```
+
+## {AIWG_ROOT} Not Replaced
+
+**Symptoms**: Literal `{AIWG_ROOT}` appears in paths instead of actual path.
+
+**Cause**: Setup command didn't complete path substitution.
+
+**Solution**:
+
+```text
+# Re-run setup to fix path substitution
+/aiwg-update-claude
+```
+
+Or manually replace `{AIWG_ROOT}` with `~/.local/share/ai-writing-guide` in CLAUDE.md.
+
+## .aiwg/ Directory Missing
+
+**Symptoms**: "Directory not found" for .aiwg/intake, .aiwg/requirements, etc.
+
+**Cause**: Project not initialized with AIWG structure.
+
+**Solution**:
+
+```bash
+# Create directory structure
+mkdir -p .aiwg/{intake,requirements,architecture,planning,risks,testing,security,quality,deployment,team,working,reports,handoffs,gates,decisions}
+
+# Or run setup
+/aiwg-setup-project
+```
+
+## Relative Path Errors
+
+**Symptoms**: Paths like `../templates/` not resolving correctly.
+
+**Cause**: Command run from wrong directory or relative path issues.
+
+**Solution**:
+
+```bash
+# Always run from project root
+cd /path/to/your/project
+
+# Use absolute paths in configuration
+# ~/.local/share/ai-writing-guide/ instead of relative paths
+```
+
+## Home Directory (~) Not Expanding
+
+**Symptoms**: Paths with `~` treated as literal character.
+
+**Cause**: Some tools don't expand `~` automatically.
+
+**Solution**:
+
+Use `$HOME` or full path instead:
+
+```bash
+# Instead of
+ls ~/. local/share/ai-writing-guide/
+
+# Use
+ls $HOME/.local/share/ai-writing-guide/
+# Or
+ls /home/YOUR_USER/.local/share/ai-writing-guide/
+```
+
+## Symlink Issues
+
+**Symptoms**: "Not a directory" or broken symlink errors.
+
+**Cause**: Symlinks pointing to moved/deleted targets.
+
+**Solution**:
+
+```bash
+# Check for broken symlinks
+find ~/.local/share/ai-writing-guide -type l -! -exec test -e {} \; -print
+
+# Reinstall to fix
+aiwg -reinstall
+```
+
+## Related
+
+- [Setup Issues](setup-issues.md) - Installation problems
+- [Deployment Issues](deployment-issues.md) - Agent deployment problems

--- a/docs/troubleshooting/platform-issues.md
+++ b/docs/troubleshooting/platform-issues.md
@@ -1,0 +1,181 @@
+# Platform Issues
+
+Problems specific to AI platforms (Claude Code, Factory AI, Warp Terminal).
+
+## Claude Code
+
+### CLAUDE.md Not Recognized
+
+**Symptoms**: Claude doesn't understand AIWG commands or context.
+
+**Cause**: CLAUDE.md missing AIWG section or not properly formatted.
+
+**Solution**:
+
+```text
+# Update CLAUDE.md with AIWG integration
+/aiwg-update-claude
+```
+
+### Natural Language Not Working
+
+**Symptoms**: Claude doesn't understand "transition to Elaboration" etc.
+
+**Cause**: CLAUDE.md missing orchestrator context.
+
+**Solution**:
+
+```text
+# Re-run intelligent merge
+/aiwg-update-claude
+
+# Verify AIWG section exists in CLAUDE.md
+# Should contain "Core Platform Orchestrator Role" section
+```
+
+### Multi-Agent Not Launching
+
+**Symptoms**: Task tool not creating subagents, single-agent responses only.
+
+**Cause**: Agents not deployed or permissions missing.
+
+**Solution**:
+
+```bash
+# Deploy agents
+aiwg -deploy-agents --mode sdlc
+
+# Check permissions in .claude/settings.local.json
+# Should allow Task tool and Read for AIWG path
+```
+
+## Factory AI
+
+### Custom Droids Not Enabled
+
+**Symptoms**: `/droids` shows no custom droids, import option missing.
+
+**Cause**: Custom Droids experimental feature not enabled.
+
+**Solution**:
+
+```bash
+# Deployment should auto-enable, but if not:
+droid
+/settings
+# Toggle "Custom Droids" under Experimental
+```
+
+### Droids Not Appearing After Deploy
+
+**Symptoms**: Files in `.factory/droids/` but not in Factory UI.
+
+**Cause**: Factory requires manual import (security feature).
+
+**Solution**:
+
+```bash
+droid .
+/droids
+# Press 'I' → 'A' → Enter
+```
+
+### AGENTS.md Not Loading
+
+**Symptoms**: Factory doesn't see project agents.
+
+**Cause**: AGENTS.md not created or not updated.
+
+**Solution**:
+
+```bash
+# Create/update AGENTS.md
+aiwg -deploy-agents --provider factory --mode sdlc --create-agents-md
+```
+
+## Warp Terminal
+
+### WARP.md Not Loading
+
+**Symptoms**: Warp AI doesn't recognize AIWG context.
+
+**Cause**: WARP.md missing or Warp not reindexed.
+
+**Solution**:
+
+```bash
+# Deploy WARP.md
+aiwg -deploy-agents --platform warp --mode sdlc
+
+# In Warp, reindex project
+/init
+```
+
+### File Too Large
+
+**Symptoms**: Warp truncating or not loading full WARP.md.
+
+**Cause**: WARP.md exceeds size limits with all agents embedded.
+
+**Solution**:
+
+```bash
+# Deploy only what you need
+aiwg -deploy-agents --platform warp --mode sdlc  # Skip general agents
+
+# Or use Claude Code for full orchestration
+```
+
+### Context Not Updating
+
+**Symptoms**: Old AIWG context showing after updates.
+
+**Cause**: Warp caching old WARP.md.
+
+**Solution**:
+
+```bash
+# Force reindex
+/init
+
+# Or restart Warp Terminal
+```
+
+## Cross-Platform
+
+### Different Behavior Across Platforms
+
+**Symptoms**: Same command works in Claude Code but not Factory/Warp.
+
+**Cause**: Platforms have different orchestration capabilities.
+
+**Solution**:
+
+Use the right platform for your task:
+
+| Task | Best Platform |
+|------|---------------|
+| Multi-agent orchestration | Claude Code |
+| Simple commands | Any |
+| Full artifact generation | Claude Code |
+| Terminal workflows | Warp |
+
+### Sync Issues Between Platforms
+
+**Symptoms**: Agents/config out of sync between platforms.
+
+**Cause**: Manual updates to one platform's files.
+
+**Solution**:
+
+```bash
+# Redeploy to all platforms
+aiwg -deploy-agents --mode sdlc                           # Claude Code
+aiwg -deploy-agents --platform warp --mode sdlc           # Warp
+aiwg -deploy-agents --provider factory --mode sdlc        # Factory
+```
+
+## Related
+
+- [Setup Issues](setup-issues.md) - Installation problems
+- [Deployment Issues](deployment-issues.md) - Agent deployment problems

--- a/docs/troubleshooting/setup-issues.md
+++ b/docs/troubleshooting/setup-issues.md
@@ -1,0 +1,100 @@
+# Setup Issues
+
+Problems during AIWG installation or project setup.
+
+## AIWG Installation Not Found
+
+**Symptoms**: "AIWG not found", "aiwg command not found"
+
+**Cause**: AIWG CLI not installed or not in PATH.
+
+**Solution**:
+
+```bash
+# Install AIWG
+curl -fsSL https://raw.githubusercontent.com/jmagly/ai-writing-guide/main/tools/install/install.sh | bash
+
+# Reload shell
+source ~/.bash_aliases  # or ~/.zshrc
+
+# Verify
+aiwg -version
+```
+
+## Installation Path Issues
+
+**Symptoms**: Commands work but templates/agents not found.
+
+**Cause**: AIWG installed in non-standard location.
+
+**Solution**:
+
+```bash
+# Check where AIWG is installed
+ls ~/.local/share/ai-writing-guide/
+
+# If installed elsewhere, set environment variable
+export AIWG_ROOT=/path/to/ai-writing-guide
+
+# Add to shell profile for persistence
+echo 'export AIWG_ROOT=/path/to/ai-writing-guide' >> ~/.bashrc
+```
+
+## Corrupt Installation
+
+**Symptoms**: Partial files, missing directories, strange errors.
+
+**Cause**: Interrupted install or git issues.
+
+**Solution**:
+
+```bash
+# Force clean reinstall
+aiwg -reinstall
+
+# Or manual cleanup
+rm -rf ~/.local/share/ai-writing-guide
+curl -fsSL https://raw.githubusercontent.com/jmagly/ai-writing-guide/main/tools/install/install.sh | bash
+```
+
+## Permission Denied
+
+**Symptoms**: "Permission denied" during install or commands.
+
+**Cause**: Insufficient permissions on install directory.
+
+**Solution**:
+
+```bash
+# Fix permissions on install directory
+chmod -R u+rwX ~/.local/share/ai-writing-guide/
+
+# If installed system-wide (not recommended)
+sudo chown -R $USER:$USER /usr/local/share/ai-writing-guide/
+```
+
+## Shell Alias Not Working
+
+**Symptoms**: `aiwg` command not found after install.
+
+**Cause**: Shell aliases not loaded.
+
+**Solution**:
+
+```bash
+# For bash
+source ~/.bash_aliases
+# Or
+source ~/.bashrc
+
+# For zsh
+source ~/.zshrc
+
+# Verify alias exists
+alias aiwg
+```
+
+## Related
+
+- [Deployment Issues](deployment-issues.md) - Agent/command deployment problems
+- [Path Issues](path-issues.md) - Template and file path errors


### PR DESCRIPTION
## Summary

Replaces inline troubleshooting in `/aiwg-setup-project` with a dedicated knowledge base approach, making help discoverable and less confusing.

**Problem**: Users interpreted the troubleshooting section in setup output as errors they needed to fix immediately.

**Solution**: 
1. Created `/aiwg-kb` command for searchable help
2. Added structured troubleshooting docs in `docs/troubleshooting/`
3. Updated `aiwg-setup-project` to point users to the KB
4. Added natural language mappings for help queries

## Changes

### New Command: `/aiwg-kb "<topic>"`

Search AIWG documentation and troubleshooting:

```text
/aiwg-kb "setup issues"
/aiwg-kb "agent not found"
/aiwg-kb "quickstart"
```

### Natural Language Support

Users can ask for help naturally:

```text
"How do I fix my AIWG install?"
"Why can't Claude find my agents?"
"Help with AIWG templates"
"What commands can I use?"
```

### New Troubleshooting Docs

- `docs/troubleshooting/index.md` - Overview and quick fixes
- `docs/troubleshooting/setup-issues.md` - Installation, PATH, permissions
- `docs/troubleshooting/deployment-issues.md` - Agents, commands, access
- `docs/troubleshooting/path-issues.md` - Templates, directories, AIWG_ROOT
- `docs/troubleshooting/platform-issues.md` - Claude Code, Factory AI, Warp

### Updated Files

- `aiwg-setup-project.md` - Replaced inline troubleshooting with KB reference
- `simple-language-translations.md` - Added Help and Troubleshooting section with regex patterns

## Test Plan

- [ ] Run `/aiwg-setup-project` - verify "Need Help?" section appears instead of inline troubleshooting
- [ ] Run `/aiwg-kb "setup"` - verify returns relevant documentation
- [ ] Say "How do I fix my AIWG install?" - verify maps to KB lookup
- [ ] Verify troubleshooting docs render correctly

Fixes #45