### PR TITLE
feat(devkit): implement AIWG Development Kit Phase 1

### DIFF
--- a/agentic/code/addons/aiwg-utils/agents/aiwg-developer.md
+++ b/agentic/code/addons/aiwg-utils/agents/aiwg-developer.md
@@ -1,0 +1,207 @@
+---
+name: aiwg-developer
+description: AIWG development expert specializing in creating and extending addons, frameworks, and extensions
+model: sonnet
+tools: Read, Write, MultiEdit, Bash, WebFetch, Glob, Grep
+---
+
+# AIWG Developer Agent
+
+Expert in AIWG (AI Writing Guide) architecture, patterns, and development. Assists users in creating, extending, and customizing AIWG components.
+
+## Domain Expertise
+
+### Primary Domain: AIWG Architecture
+
+- **Three-tier plugin taxonomy**: Frameworks, Addons, Extensions
+- **Manifest schema**: Required fields, entry points, versioning
+- **Directory conventions**: agents/, commands/, skills/, templates/
+- **Deployment patterns**: Claude Code, Warp Terminal, Factory AI, OpenAI
+
+### Secondary Domains
+
+- **Agent design**: Expertise definition, tool selection, workflow patterns
+- **Command design**: Arguments, options, execution steps
+- **Skill design**: Trigger phrases, activation patterns
+- **Template design**: Document types, variable substitution
+
+## Knowledge Base
+
+### Three-Tier Taxonomy (ADR-008)
+
+| Tier | Type | Purpose | Standalone |
+|------|------|---------|------------|
+| 1 | Framework | Complete lifecycle solution | ✅ Yes |
+| 2 | Addon | Standalone utility | ✅ Yes |
+| 3 | Extension | Framework expansion pack | ❌ No |
+
+**Key distinctions:**
+- Frameworks are large (50+ agents), define phases and workflows
+- Addons are small (1-10 agents), work anywhere
+- Extensions require a parent framework, add domain-specific content
+
+### Manifest Required Fields
+
+**All types:**
+- `id`: Kebab-case identifier
+- `type`: "addon", "framework", or "extension"
+- `name`: Human-readable name
+- `version`: Semantic version (e.g., "1.0.0")
+- `description`: Purpose description
+
+**Extensions only:**
+- `requires`: Array of parent framework IDs
+
+### Agent Templates
+
+| Template | Use Case | Model |
+|----------|----------|-------|
+| simple | Single-purpose utility | sonnet |
+| complex | Domain expert | sonnet |
+| orchestrator | Multi-agent coordination | opus |
+
+### Command Templates
+
+| Template | Use Case |
+|----------|----------|
+| utility | Single action, quick task |
+| transformation | Input → processing → output |
+| orchestration | Multi-agent workflow |
+
+## Responsibilities
+
+### Primary
+
+1. **Guide addon creation**: Help users create well-structured addons
+2. **Guide extension creation**: Help users extend frameworks properly
+3. **Component development**: Assist with agents, commands, skills
+4. **Structure validation**: Verify manifests and directory structure
+5. **Pattern advice**: Recommend appropriate patterns for use cases
+
+### Quality Assurance
+
+1. **Manifest validation**: Check required fields and references
+2. **Frontmatter validation**: Verify agent/command frontmatter
+3. **Naming conventions**: Ensure kebab-case identifiers
+4. **Best practices**: Recommend AIWG patterns
+
+## Common Questions I Can Answer
+
+### Architecture
+
+- "What's the difference between an addon and an extension?"
+- "When should I create a framework vs an addon?"
+- "How do extensions inherit from frameworks?"
+
+### Development
+
+- "How do I create a new addon?"
+- "What template should I use for my agent?"
+- "How do I add a command to an existing framework?"
+
+### Troubleshooting
+
+- "Why isn't my agent appearing after deployment?"
+- "How do I fix a manifest validation error?"
+- "Why can't I find my extension's templates?"
+
+## Workflow
+
+### For Addon/Extension Questions
+
+1. Understand the user's goal
+2. Determine appropriate type (addon vs extension vs framework)
+3. Recommend structure and components
+4. Guide through creation process
+5. Validate result
+
+### For Component Questions
+
+1. Identify target addon/framework
+2. Recommend appropriate template
+3. Help define expertise/behavior
+4. Generate component file
+5. Update manifest
+
+### For Troubleshooting
+
+1. Gather error details
+2. Check manifest structure
+3. Verify file locations
+4. Check frontmatter syntax
+5. Recommend fixes
+
+## Output Format
+
+### Creation Guidance
+
+```
+## Recommendation
+
+Based on your requirements, I recommend creating a(n) [type]:
+
+**Name**: [suggested-name]
+**Purpose**: [brief description]
+**Components**:
+- [component 1]: [purpose]
+- [component 2]: [purpose]
+
+## Next Steps
+
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+## CLI Commands
+
+\`\`\`bash
+[relevant CLI commands]
+\`\`\`
+```
+
+### Troubleshooting
+
+```
+## Issue Analysis
+
+**Problem**: [description]
+**Cause**: [root cause]
+
+## Solution
+
+[Step-by-step fix]
+
+## Prevention
+
+[How to avoid in future]
+```
+
+## Reference Paths
+
+- AIWG installation: `~/.local/share/ai-writing-guide`
+- Frameworks: `agentic/code/frameworks/`
+- Addons: `agentic/code/addons/`
+- Devkit templates: `agentic/code/addons/aiwg-utils/templates/devkit/`
+- ADR-008 (taxonomy): `.aiwg/architecture/decisions/ADR-008-plugin-type-taxonomy.md`
+- Development plan: `.aiwg/planning/aiwg-devkit-plan.md`
+
+## CLI Tools I Can Help With
+
+| Command | Purpose |
+|---------|---------|
+| `aiwg scaffold-addon` | Create new addon |
+| `aiwg scaffold-extension` | Create extension |
+| `aiwg add-agent` | Add agent to target |
+| `aiwg add-command` | Add command to target |
+| `aiwg add-skill` | Add skill to target |
+| `aiwg add-template` | Add template to framework/extension |
+
+## In-Session Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/devkit-create-addon` | Interactive addon creation |
+| `/devkit-create-extension` | Interactive extension creation |
+| `/devkit-create-agent` | Interactive agent creation |
+| `/devkit-create-command` | Interactive command creation |
+| `/devkit-validate` | Validate package structure |

--- a/agentic/code/addons/aiwg-utils/commands/devkit-create-addon.md
+++ b/agentic/code/addons/aiwg-utils/commands/devkit-create-addon.md
@@ -1,0 +1,84 @@
+---
+name: devkit-create-addon
+description: Create a new AIWG addon with AI-guided setup
+args: <name> [--interactive]
+---
+
+# Create AIWG Addon
+
+Create a new standalone addon with AI assistance.
+
+## Usage
+
+```
+/devkit-create-addon <name> [--interactive]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| name | Yes | Addon name (kebab-case recommended) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| --interactive | Enable interactive mode with guided questions |
+
+## What This Creates
+
+```
+agentic/code/addons/<name>/
+├── manifest.json      # Addon configuration
+├── README.md          # Documentation
+├── agents/            # Agent definitions
+├── commands/          # Slash commands
+└── skills/            # Auto-triggered skills
+```
+
+## Interactive Mode
+
+When `--interactive` is specified, I will ask:
+
+1. **Purpose**: What is the primary purpose of this addon?
+2. **Capabilities**: What specific capabilities should it provide?
+3. **Initial agents**: Should I create any starter agents?
+4. **Initial commands**: Should I create any starter commands?
+5. **Core status**: Should this be a core addon (auto-installed)?
+
+## Examples
+
+```bash
+# Quick creation
+/devkit-create-addon security-scanner
+
+# Interactive guided creation
+/devkit-create-addon code-metrics --interactive
+```
+
+## Execution
+
+1. **Validate name**: Ensure name follows kebab-case convention
+2. **Check existence**: Verify addon doesn't already exist
+3. **Gather info**: In interactive mode, ask clarifying questions
+4. **Generate manifest**: Create manifest.json with appropriate fields
+5. **Create structure**: Build directory structure
+6. **Generate README**: Create documentation with usage instructions
+7. **Optionally create components**: If interactive, offer to create initial agents/commands
+8. **Report success**: Show created files and next steps
+
+## CLI Equivalent
+
+For non-interactive creation, you can also use:
+
+```bash
+aiwg scaffold-addon <name> --description "..." --author "..."
+```
+
+## Related Commands
+
+- `/devkit-create-agent` - Add agent to addon
+- `/devkit-create-command` - Add command to addon
+- `/devkit-create-skill` - Add skill to addon
+- `/devkit-validate` - Validate addon structure

--- a/agentic/code/addons/aiwg-utils/commands/devkit-create-agent.md
+++ b/agentic/code/addons/aiwg-utils/commands/devkit-create-agent.md
@@ -1,0 +1,130 @@
+---
+name: devkit-create-agent
+description: Create a new agent with AI-guided expertise definition
+args: <name> --to <target> [--template <type>] [--interactive]
+---
+
+# Create AIWG Agent
+
+Create a new agent with AI assistance to define expertise, workflow, and capabilities.
+
+## Usage
+
+```
+/devkit-create-agent <name> --to <target> [options]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| name | Yes | Agent name (kebab-case recommended) |
+
+## Required Options
+
+| Option | Description |
+|--------|-------------|
+| --to | Target addon or framework |
+
+## Optional Options
+
+| Option | Description |
+|--------|-------------|
+| --template | Agent template: simple (default), complex, orchestrator |
+| --interactive | Enable interactive mode with guided questions |
+
+## Templates
+
+### simple (default)
+Single-purpose, focused agent with minimal structure.
+- Best for: Utility agents, single-task specialists
+- Tools: Read, Write, MultiEdit, Bash, WebFetch
+
+### complex
+Domain expert with deep knowledge sections, patterns, and anti-patterns.
+- Best for: Subject matter experts, reviewers, analysts
+- Tools: Read, Write, MultiEdit, Bash, WebFetch, Glob, Grep
+
+### orchestrator
+Multi-agent coordination with workflow patterns and agent assignment tables.
+- Best for: Workflow coordinators, phase managers, CI/CD orchestrators
+- Tools: Read, Write, MultiEdit, Bash, WebFetch, Task
+
+## Interactive Mode
+
+When `--interactive` is specified, I will ask:
+
+1. **Role**: What is this agent's primary role?
+2. **Expertise**: What domains does it specialize in?
+3. **Responsibilities**: What are its key responsibilities?
+4. **Tools**: What tools does it need access to?
+5. **Workflow**: How should it approach tasks?
+6. **Output**: What format should its output take?
+
+## Examples
+
+```bash
+# Simple agent
+/devkit-create-agent code-reviewer --to aiwg-utils
+
+# Complex domain expert
+/devkit-create-agent security-auditor --to sdlc-complete --template complex
+
+# Orchestrator agent
+/devkit-create-agent deployment-coordinator --to sdlc-complete --template orchestrator --interactive
+```
+
+## Execution
+
+1. **Validate inputs**: Check name and target
+2. **Verify target exists**: Ensure addon/framework is installed
+3. **Select template**: Use specified or default to simple
+4. **Gather expertise**: In interactive mode, ask about domain knowledge
+5. **Generate agent file**: Create with frontmatter and sections
+6. **Update manifest**: Add agent to manifest.json
+7. **Report success**: Show location and customization tips
+
+## Output Location
+
+```
+<target>/agents/<name>.md
+```
+
+## Agent File Structure
+
+```markdown
+---
+name: agent-name
+description: Agent description
+model: sonnet
+tools: Read, Write, MultiEdit, Bash, WebFetch
+---
+
+# Agent Title
+
+[Description]
+
+## Expertise
+[Domain knowledge]
+
+## Responsibilities
+[What the agent does]
+
+## Workflow
+[How it approaches tasks]
+
+## Output Format
+[Expected output structure]
+```
+
+## CLI Equivalent
+
+```bash
+aiwg add-agent <name> --to <target> --template <type>
+```
+
+## Related Commands
+
+- `/devkit-create-command` - Create a slash command
+- `/devkit-create-skill` - Create an auto-triggered skill
+- `/devkit-validate` - Validate agent structure

--- a/agentic/code/addons/aiwg-utils/commands/devkit-create-command.md
+++ b/agentic/code/addons/aiwg-utils/commands/devkit-create-command.md
@@ -1,0 +1,131 @@
+---
+name: devkit-create-command
+description: Create a new slash command with AI-guided behavior definition
+args: <name> --to <target> [--template <type>] [--interactive]
+---
+
+# Create AIWG Command
+
+Create a new slash command with AI assistance to define arguments, behavior, and output.
+
+## Usage
+
+```
+/devkit-create-command <name> --to <target> [options]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| name | Yes | Command name (kebab-case recommended) |
+
+## Required Options
+
+| Option | Description |
+|--------|-------------|
+| --to | Target addon or framework |
+
+## Optional Options
+
+| Option | Description |
+|--------|-------------|
+| --template | Command template: utility (default), transformation, orchestration |
+| --interactive | Enable interactive mode with guided questions |
+
+## Templates
+
+### utility (default)
+Simple operation, single action command.
+- Best for: Quick tasks, file operations, status checks
+- Example: `/lint-check`, `/deploy-status`
+
+### transformation
+Content/code transformation pipeline with input/output handling.
+- Best for: Format conversion, code refactoring, content processing
+- Example: `/convert-format`, `/refactor-code`
+
+### orchestration
+Multi-agent workflow coordination with phases and parallel execution.
+- Best for: Complex workflows, phase transitions, multi-step processes
+- Example: `/flow-deploy-to-production`, `/flow-security-review`
+
+## Interactive Mode
+
+When `--interactive` is specified, I will ask:
+
+1. **Purpose**: What does this command do?
+2. **Arguments**: What inputs does it need?
+3. **Options**: What configuration options should it support?
+4. **Steps**: What are the execution steps?
+5. **Output**: What should the output look like?
+
+## Examples
+
+```bash
+# Simple utility command
+/devkit-create-command lint-fix --to aiwg-utils
+
+# Transformation pipeline
+/devkit-create-command convert-docs --to sdlc-complete --template transformation
+
+# Orchestration workflow
+/devkit-create-command deploy-all --to sdlc-complete --template orchestration --interactive
+```
+
+## Execution
+
+1. **Validate inputs**: Check name and target
+2. **Verify target exists**: Ensure addon/framework is installed
+3. **Select template**: Use specified or default to utility
+4. **Gather behavior**: In interactive mode, ask about command behavior
+5. **Generate command file**: Create with frontmatter and sections
+6. **Update manifest**: Add command to manifest.json
+7. **Report success**: Show location and usage instructions
+
+## Output Location
+
+```
+<target>/commands/<name>.md
+```
+
+## Command File Structure
+
+```markdown
+---
+name: command-name
+description: Command description
+args: [arg1] [--option value]
+---
+
+# Command Title
+
+[Description]
+
+## Usage
+[How to invoke]
+
+## Arguments
+[Input parameters]
+
+## Options
+[Configuration flags]
+
+## Execution
+[Step-by-step behavior]
+
+## Output
+[What to expect]
+```
+
+## CLI Equivalent
+
+```bash
+aiwg add-command <name> --to <target> --template <type>
+```
+
+## Related Commands
+
+- `/devkit-create-agent` - Create an agent
+- `/devkit-create-skill` - Create an auto-triggered skill
+- `/devkit-validate` - Validate command structure

--- a/agentic/code/addons/aiwg-utils/commands/devkit-create-extension.md
+++ b/agentic/code/addons/aiwg-utils/commands/devkit-create-extension.md
@@ -1,0 +1,106 @@
+---
+name: devkit-create-extension
+description: Create a new AIWG extension (framework expansion pack) with AI-guided setup
+args: <name> --for <framework> [--interactive]
+---
+
+# Create AIWG Extension
+
+Create a new extension (framework expansion pack) with AI assistance.
+
+Extensions enhance a specific parent framework with additional templates, checklists, and domain-specific content. They cannot operate standalone.
+
+## Usage
+
+```
+/devkit-create-extension <name> --for <framework> [--interactive]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| name | Yes | Extension name (kebab-case recommended) |
+
+## Required Options
+
+| Option | Description |
+|--------|-------------|
+| --for | Parent framework ID (e.g., sdlc-complete, media-marketing-kit) |
+
+## Optional Options
+
+| Option | Description |
+|--------|-------------|
+| --interactive | Enable interactive mode with guided questions |
+
+## What This Creates
+
+```
+agentic/code/frameworks/<framework>/extensions/<name>/
+├── manifest.json      # type: "extension", requires: ["<framework>"]
+├── README.md          # Documentation
+├── templates/         # Domain-specific templates
+└── checklists/        # Compliance/verification checklists
+```
+
+## Interactive Mode
+
+When `--interactive` is specified, I will ask:
+
+1. **Domain**: What compliance/domain does this extension address?
+2. **Purpose**: What specific requirements or standards does it cover?
+3. **Templates**: What templates should be included?
+4. **Checklists**: What verification checklists are needed?
+5. **Dependencies**: Does it depend on other extensions?
+
+## Examples
+
+```bash
+# Quick creation
+/devkit-create-extension hipaa --for sdlc-complete
+
+# Interactive guided creation
+/devkit-create-extension sox --for sdlc-complete --interactive
+```
+
+## Common Extension Types
+
+### Compliance Extensions
+- `gdpr` - EU data protection
+- `hipaa` - Healthcare (US)
+- `sox` - Financial controls (US)
+- `pci-dss` - Payment card security
+- `ftc` - FTC advertising rules
+
+### Domain Extensions
+- `healthcare` - Healthcare-specific templates
+- `fintech` - Financial technology patterns
+- `government` - Government/public sector
+
+## Execution
+
+1. **Validate inputs**: Check name and framework
+2. **Verify framework exists**: Ensure parent framework is installed
+3. **Check for duplicates**: Verify extension doesn't exist
+4. **Gather info**: In interactive mode, ask about domain and needs
+5. **Generate manifest**: Create with `requires` field for parent
+6. **Create structure**: Build templates/ and checklists/ directories
+7. **Generate README**: Document extension purpose and usage
+8. **Optionally create content**: Offer to create initial templates/checklists
+9. **Report success**: Show created files and activation instructions
+
+## CLI Equivalent
+
+For non-interactive creation:
+
+```bash
+aiwg scaffold-extension <name> --for <framework> --description "..."
+```
+
+## Related Commands
+
+- `/devkit-create-addon` - Create standalone addon
+- `/devkit-create-framework` - Create full framework
+- `/devkit-validate` - Validate extension structure
+- `aiwg add-template` - Add template to extension

--- a/agentic/code/addons/aiwg-utils/commands/devkit-validate.md
+++ b/agentic/code/addons/aiwg-utils/commands/devkit-validate.md
@@ -1,0 +1,153 @@
+---
+name: devkit-validate
+description: Validate addon, framework, or extension structure and manifest
+args: <path> [--fix] [--verbose]
+---
+
+# Validate AIWG Package
+
+Validate the structure and manifest of an addon, framework, or extension.
+
+## Usage
+
+```
+/devkit-validate <path> [options]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| path | Yes | Path to addon, framework, or extension |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| --fix | Attempt to auto-fix common issues |
+| --verbose | Show detailed validation output |
+
+## What It Validates
+
+### Manifest Validation
+
+- [ ] `manifest.json` exists
+- [ ] Required fields present: id, type, name, version, description
+- [ ] Type is valid: addon, framework, or extension
+- [ ] For extensions: `requires` field specifies valid parent framework
+- [ ] All referenced agents exist in agents/ directory
+- [ ] All referenced commands exist in commands/ directory
+- [ ] All referenced skills exist in skills/ directory
+- [ ] All referenced templates exist in templates/ directory
+
+### Structure Validation
+
+- [ ] Directory structure matches type expectations
+- [ ] README.md exists
+- [ ] Entry directories exist if specified
+- [ ] No orphaned files (files not in manifest)
+
+### Content Validation
+
+- [ ] Agent files have valid frontmatter (name, description, model, tools)
+- [ ] Command files have valid frontmatter (name, description, args)
+- [ ] Skill directories have SKILL.md with required fields
+
+### Extension-Specific Validation
+
+- [ ] Parent framework exists
+- [ ] Extension is in parent's extensions/ directory
+- [ ] `requires` field matches parent location
+
+## Examples
+
+```bash
+# Validate addon
+/devkit-validate agentic/code/addons/aiwg-utils
+
+# Validate framework
+/devkit-validate agentic/code/frameworks/sdlc-complete
+
+# Validate extension
+/devkit-validate agentic/code/frameworks/sdlc-complete/extensions/gdpr
+
+# Validate with auto-fix
+/devkit-validate agentic/code/addons/my-addon --fix
+
+# Verbose output
+/devkit-validate . --verbose
+```
+
+## Output Format
+
+### Success
+
+```
+✓ Validating: agentic/code/addons/aiwg-utils
+  Type: addon
+  Version: 1.1.0
+
+✓ Manifest: Valid
+  - id: aiwg-utils
+  - agents: 1 (1 found)
+  - commands: 10 (10 found)
+  - skills: 2 (2 found)
+
+✓ Structure: Valid
+  - agents/: OK
+  - commands/: OK
+  - skills/: OK
+
+✓ Content: Valid
+  - Agent frontmatter: OK
+  - Command frontmatter: OK
+  - Skill definitions: OK
+
+═══════════════════════════════
+VALIDATION PASSED
+═══════════════════════════════
+```
+
+### Failure
+
+```
+✓ Validating: agentic/code/addons/my-addon
+  Type: addon
+  Version: 1.0.0
+
+✓ Manifest: Valid
+  - id: my-addon
+
+✗ Structure: Issues Found
+  - agents/: Missing (manifest references 2 agents)
+  - commands/: OK
+
+✗ Content: Issues Found
+  - Missing: agents/code-reviewer.md
+  - Missing: agents/security-auditor.md
+
+═══════════════════════════════
+VALIDATION FAILED (2 errors)
+═══════════════════════════════
+
+Errors:
+1. Directory 'agents/' does not exist
+2. Referenced agent 'code-reviewer' not found
+
+To fix, run: /devkit-validate <path> --fix
+```
+
+## Auto-Fix Capabilities
+
+When `--fix` is specified:
+
+1. **Create missing directories**: agents/, commands/, skills/
+2. **Update manifest**: Remove references to non-existent files
+3. **Add missing entries**: Add files found in directories but not in manifest
+4. **Fix frontmatter**: Add required fields with defaults
+
+## Related Commands
+
+- `/devkit-create-addon` - Create new addon
+- `/devkit-create-extension` - Create new extension
+- `aiwg validate` - CLI validation tool

--- a/agentic/code/addons/aiwg-utils/manifest.json
+++ b/agentic/code/addons/aiwg-utils/manifest.json
@@ -2,8 +2,8 @@
   "id": "aiwg-utils",
   "type": "addon",
   "name": "AIWG Utilities",
-  "version": "1.1.0",
-  "description": "Core meta-utilities for AIWG management including context regeneration and workspace maintenance",
+  "version": "1.2.0",
+  "description": "Core meta-utilities for AIWG management including context regeneration, workspace maintenance, and development kit",
   "core": true,
   "autoInstall": true,
   "author": "AIWG Contributors",
@@ -18,12 +18,15 @@
     "warp",
     "factory",
     "workspace",
-    "maintenance"
+    "maintenance",
+    "devkit",
+    "scaffolding"
   ],
   "entry": {
     "agents": "agents/",
     "commands": "commands/",
-    "skills": "skills/"
+    "skills": "skills/",
+    "templates": "templates/"
   },
   "commands": [
     "aiwg-regenerate",
@@ -35,12 +38,23 @@
     "workspace-reset",
     "commit-and-push",
     "roko-voice",
-    "summarize-transcript"
+    "summarize-transcript",
+    "devkit-create-addon",
+    "devkit-create-extension",
+    "devkit-create-agent",
+    "devkit-create-command",
+    "devkit-validate"
   ],
   "agents": [
-    "context-regenerator"
+    "context-regenerator",
+    "aiwg-developer"
   ],
   "skills": [
     "project-awareness"
+  ],
+  "templates": [
+    "devkit/addon-manifest",
+    "devkit/framework-manifest",
+    "devkit/extension-manifest"
   ]
 }

--- a/agentic/code/addons/aiwg-utils/templates/devkit/addon-manifest.json
+++ b/agentic/code/addons/aiwg-utils/templates/devkit/addon-manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "{{id}}",
+  "type": "addon",
+  "name": "{{name}}",
+  "version": "1.0.0",
+  "description": "{{description}}",
+  "author": "{{author}}",
+  "core": false,
+  "autoInstall": false,
+  "entry": {
+    "agents": "agents",
+    "commands": "commands",
+    "skills": "skills"
+  },
+  "agents": [],
+  "commands": [],
+  "skills": []
+}

--- a/agentic/code/addons/aiwg-utils/templates/devkit/extension-manifest.json
+++ b/agentic/code/addons/aiwg-utils/templates/devkit/extension-manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "{{id}}",
+  "type": "extension",
+  "name": "{{name}}",
+  "version": "1.0.0",
+  "description": "{{description}}",
+  "requires": ["{{framework}}"],
+  "author": "{{author}}",
+  "entry": {
+    "templates": "templates",
+    "checklists": "checklists"
+  },
+  "templates": [],
+  "checklists": []
+}

--- a/agentic/code/addons/aiwg-utils/templates/devkit/framework-manifest.json
+++ b/agentic/code/addons/aiwg-utils/templates/devkit/framework-manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "{{id}}",
+  "type": "framework",
+  "name": "{{name}}",
+  "version": "1.0.0",
+  "description": "{{description}}",
+  "author": "{{author}}",
+  "entry": {
+    "agents": "agents",
+    "commands": "commands",
+    "skills": "skills",
+    "templates": "templates",
+    "flows": "flows"
+  },
+  "agents": [],
+  "commands": [],
+  "skills": [],
+  "templates": [],
+  "flows": []
+}

--- a/tools/install/install.sh
+++ b/tools/install/install.sh
@@ -295,6 +295,14 @@ fi
     -validate-metadata|--validate-metadata) node \"$PREFIX/tools/cli/validate-metadata.mjs\" \"\$@\" ;; \\
     -wipe-working|--wipe-working) node \"$PREFIX/tools/cli/workspace-wipe-working.mjs\" \"\$@\" ;; \\
     -reset-workspace|--reset-workspace) node \"$PREFIX/tools/cli/workspace-reset.mjs\" \"\$@\" ;; \\
+    scaffold-addon) node \"$PREFIX/tools/scaffolding/scaffold-addon.mjs\" \"\$@\" ;; \\
+    scaffold-extension) node \"$PREFIX/tools/scaffolding/scaffold-extension.mjs\" \"\$@\" ;; \\
+    scaffold-framework) node \"$PREFIX/tools/scaffolding/scaffold-framework.mjs\" \"\$@\" ;; \\
+    add-agent) node \"$PREFIX/tools/scaffolding/add-agent.mjs\" \"\$@\" ;; \\
+    add-command) node \"$PREFIX/tools/scaffolding/add-command.mjs\" \"\$@\" ;; \\
+    add-skill) node \"$PREFIX/tools/scaffolding/add-skill.mjs\" \"\$@\" ;; \\
+    add-template) node \"$PREFIX/tools/scaffolding/add-template.mjs\" \"\$@\" ;; \\
+    validate) node \"$PREFIX/tools/scaffolding/validate.mjs\" \"\$@\" ;; \\
     -version|--version|version) aiwg_version ;; \\
     -update|--update|update) echo 'Updating ai-writing-guide...'; git -C \"$PREFIX\" fetch --all && git -C \"$PREFIX\" pull --ff-only && echo 'Update complete. Re-running installer to refresh aliases...' && bash \"$PREFIX/tools/install/install.sh\" && echo 'Please run: source ~/.bash_aliases (or ~/.zshrc) to activate new commands' ;; \\
     -reinstall|--reinstall|reinstall) aiwg_reinstall ;; \\
@@ -321,6 +329,21 @@ fi
       echo '      Wipe .aiwg/working/ temporary files'; \\
       echo '  -reset-workspace [--backup] [--keep-intake] [--reinitialize]'; \\
       echo '      Reset entire .aiwg/ workspace'; echo ''; \\
+      echo 'Development Kit:'; \\
+      echo '  scaffold-addon <name> [--description] [--author]'; \\
+      echo '      Create new addon structure'; \\
+      echo '  scaffold-extension <name> --for <framework>'; \\
+      echo '      Create framework extension (expansion pack)'; \\
+      echo '  add-agent <name> --to <target> [--template simple|complex|orchestrator]'; \\
+      echo '      Add agent to addon/framework'; \\
+      echo '  add-command <name> --to <target> [--template utility|transformation|orchestration]'; \\
+      echo '      Add slash command to addon/framework'; \\
+      echo '  add-skill <name> --to <target>'; \\
+      echo '      Add skill to addon/framework'; \\
+      echo '  add-template <name> --to <target> [--type document|checklist|matrix|form]'; \\
+      echo '      Add template to framework/extension'; \\
+      echo '  validate <path>'; \\
+      echo '      Validate addon/framework/extension structure'; echo ''; \\
       echo 'Utilities:'; \\
       echo '  -prefill-cards --target <path> --team <team.yml> [--write]'; \\
       echo '      Prefill SDLC card metadata'; \\

--- a/tools/scaffolding/add-agent.mjs
+++ b/tools/scaffolding/add-agent.mjs
@@ -1,0 +1,443 @@
+#!/usr/bin/env node
+
+/**
+ * CLI tool to add an agent to an existing addon, framework, or extension
+ * Usage: aiwg add-agent <name> --to <target> [options]
+ */
+
+import {
+  parseArgs,
+  formatName,
+  ensureDir,
+  writeFileIfNotExists,
+  updateManifest,
+  resolveTargetPath,
+  loadTemplate,
+  substituteTemplate,
+  printSuccess,
+  printError,
+  printInfo,
+  printHeader,
+  listAddons,
+  listFrameworks,
+} from './utils.mjs';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const { positional, flags } = parseArgs(process.argv);
+
+const name = positional[0];
+const target = flags.to || flags.t;
+const template = flags.template || 'simple';
+const agentDescription = flags.description || flags.d || `${formatName(name || 'agent').title} agent`;
+const tools = flags.tools || 'Read, Write, MultiEdit, Bash, WebFetch';
+const dryRun = flags['dry-run'] || flags.n;
+const help = flags.help || flags.h;
+
+const VALID_TEMPLATES = ['simple', 'complex', 'orchestrator'];
+
+function printHelp() {
+  const addons = listAddons();
+  const frameworks = listFrameworks();
+
+  console.log(`
+Usage: aiwg add-agent <name> --to <target> [options]
+
+Add a new agent to an existing addon, framework, or extension.
+
+Arguments:
+  name                  Agent name (kebab-case recommended)
+
+Required:
+  --to, -t              Target addon, framework, or extension path
+
+Options:
+  --template            Agent template: simple (default), complex, orchestrator
+  --description, -d     Agent description
+  --tools               Comma-separated tools (default: Read, Write, MultiEdit, Bash, WebFetch)
+  --dry-run, -n         Preview what would be created
+  --help, -h            Show this help
+
+Templates:
+  simple       Single-purpose, focused agent (default)
+  complex      Domain expert with deep knowledge sections
+  orchestrator Multi-agent coordination patterns
+
+Available Targets:
+  Addons:     ${addons.length > 0 ? addons.join(', ') : '(none)'}
+  Frameworks: ${frameworks.length > 0 ? frameworks.join(', ') : '(none)'}
+  Extensions: <framework>/extensions/<name>
+
+Examples:
+  aiwg add-agent code-reviewer --to aiwg-utils
+  aiwg add-agent security-auditor --to sdlc-complete --template complex
+  aiwg add-agent compliance-checker --to sdlc-complete/extensions/hipaa
+`);
+}
+
+function generateAgentSimple(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `---
+name: ${kebab}
+description: ${options.description}
+model: sonnet
+tools: ${options.tools}
+---
+
+# ${title} Agent
+
+${options.description}
+
+## Expertise
+
+- [Define primary expertise area]
+- [Define secondary capabilities]
+
+## Responsibilities
+
+1. [Primary responsibility]
+2. [Secondary responsibility]
+3. [Quality checks]
+
+## Workflow
+
+1. Understand the request
+2. Gather necessary context
+3. Execute the task
+4. Validate output quality
+5. Report results
+
+## Output Format
+
+Provide clear, structured output with:
+- Summary of actions taken
+- Key findings or results
+- Recommendations if applicable
+`;
+}
+
+function generateAgentComplex(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `---
+name: ${kebab}
+description: ${options.description}
+model: sonnet
+tools: ${options.tools}
+---
+
+# ${title} Agent
+
+${options.description}
+
+## Domain Expertise
+
+### Primary Domain
+- [Core domain knowledge]
+- [Key concepts and terminology]
+- [Industry standards and best practices]
+
+### Secondary Domains
+- [Related expertise area 1]
+- [Related expertise area 2]
+
+## Responsibilities
+
+### Primary
+1. [Core responsibility with detailed expectations]
+2. [Key deliverable responsibility]
+
+### Quality Assurance
+1. [Validation criteria]
+2. [Error handling approach]
+3. [Edge case considerations]
+
+## Knowledge Base
+
+### Standards & Frameworks
+- [Relevant standard 1]
+- [Relevant framework 1]
+
+### Common Patterns
+- [Pattern 1]: [When to use, how to apply]
+- [Pattern 2]: [When to use, how to apply]
+
+### Anti-Patterns
+- [Anti-pattern 1]: [Why to avoid, what to do instead]
+
+## Workflow
+
+### Analysis Phase
+1. Gather requirements and context
+2. Identify constraints and dependencies
+3. Assess complexity and risk
+
+### Execution Phase
+1. Plan approach based on analysis
+2. Execute in logical steps
+3. Validate at checkpoints
+
+### Delivery Phase
+1. Compile results
+2. Document decisions and rationale
+3. Provide actionable recommendations
+
+## Output Format
+
+### Standard Output
+\`\`\`
+## Summary
+[Brief overview]
+
+## Findings
+- [Finding 1]
+- [Finding 2]
+
+## Recommendations
+1. [Recommendation with rationale]
+
+## Next Steps
+- [Actionable next step]
+\`\`\`
+
+## Error Handling
+
+- **Missing context**: Request clarification before proceeding
+- **Ambiguous requirements**: List interpretations and ask for confirmation
+- **Conflicting constraints**: Highlight trade-offs and recommend approach
+`;
+}
+
+function generateAgentOrchestrator(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `---
+name: ${kebab}
+description: ${options.description}
+model: opus
+tools: ${options.tools}, Task
+---
+
+# ${title} Orchestrator
+
+${options.description}
+
+## Role
+
+This is an **orchestrator agent** that coordinates multiple specialized agents to accomplish complex, multi-step tasks.
+
+## Orchestration Capabilities
+
+### Agent Coordination
+- Launch parallel agents when tasks are independent
+- Sequence dependent tasks appropriately
+- Aggregate and synthesize results from multiple agents
+
+### Workflow Management
+- Break complex tasks into sub-tasks
+- Assign sub-tasks to appropriate specialist agents
+- Track progress and handle failures gracefully
+
+## Available Agents
+
+| Agent | Purpose | When to Use |
+|-------|---------|-------------|
+| [agent-1] | [purpose] | [conditions] |
+| [agent-2] | [purpose] | [conditions] |
+
+## Orchestration Patterns
+
+### Parallel Review Pattern
+\`\`\`
+Primary Author → Parallel Reviewers → Synthesizer → Archive
+     ↓                ↓                    ↓           ↓
+  Draft v0.1    Reviews (3-5)      Final merge    Output
+\`\`\`
+
+### Sequential Pipeline Pattern
+\`\`\`
+Analysis → Design → Implementation → Validation → Delivery
+\`\`\`
+
+### Fan-Out/Fan-In Pattern
+\`\`\`
+Split Task → Multiple Workers → Aggregate Results → Deliver
+\`\`\`
+
+## Workflow
+
+### 1. Task Analysis
+- Understand the overall goal
+- Identify required sub-tasks
+- Determine dependencies between sub-tasks
+
+### 2. Agent Selection
+- Match sub-tasks to specialist agents
+- Consider agent expertise and availability
+- Plan parallel vs sequential execution
+
+### 3. Execution
+- Launch agents with clear prompts
+- Monitor progress
+- Handle failures and retries
+
+### 4. Synthesis
+- Collect results from all agents
+- Resolve conflicts between outputs
+- Synthesize into cohesive deliverable
+
+### 5. Delivery
+- Compile final output
+- Document process and decisions
+- Archive artifacts
+
+## Output Format
+
+### Progress Updates
+\`\`\`
+✓ = Complete
+⏳ = In progress
+❌ = Error/blocked
+⚠️ = Warning/attention needed
+
+[Task 1] ✓ Complete
+[Task 2] ⏳ Running agent-x...
+[Task 3] Pending
+\`\`\`
+
+### Final Output
+\`\`\`
+## Orchestration Complete
+
+### Summary
+[What was accomplished]
+
+### Agents Used
+- [agent-1]: [contribution]
+- [agent-2]: [contribution]
+
+### Artifacts Created
+- [artifact 1]: [location]
+- [artifact 2]: [location]
+
+### Issues Encountered
+- [Issue and resolution]
+
+### Recommendations
+- [Follow-up actions]
+\`\`\`
+
+## Error Handling
+
+- **Agent failure**: Retry once, then report and continue with alternatives
+- **Timeout**: Report status and offer to continue or abort
+- **Conflicting outputs**: Flag for human review with analysis
+`;
+}
+
+function generateAgent(name, templateType, options) {
+  switch (templateType) {
+    case 'complex':
+      return generateAgentComplex(name, options);
+    case 'orchestrator':
+      return generateAgentOrchestrator(name, options);
+    case 'simple':
+    default:
+      return generateAgentSimple(name, options);
+  }
+}
+
+async function main() {
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!name) {
+    printError('Agent name is required.');
+    printHelp();
+    process.exit(1);
+  }
+
+  if (!target) {
+    printError('Target is required. Use --to <addon|framework|extension>');
+    process.exit(1);
+  }
+
+  if (!VALID_TEMPLATES.includes(template)) {
+    printError(`Invalid template: ${template}. Valid options: ${VALID_TEMPLATES.join(', ')}`);
+    process.exit(1);
+  }
+
+  const { kebab, title } = formatName(name);
+  const resolved = resolveTargetPath(target);
+
+  if (!resolved) {
+    printError(`Target not found: ${target}`);
+    printInfo('Check that the addon, framework, or extension exists.');
+    process.exit(1);
+  }
+
+  const agentsDir = join(resolved.path, 'agents');
+  const agentPath = join(agentsDir, `${kebab}.md`);
+  const manifestPath = join(resolved.path, 'manifest.json');
+
+  // Check if agent already exists
+  if (existsSync(agentPath)) {
+    printError(`Agent already exists: ${agentPath}`);
+    process.exit(1);
+  }
+
+  printHeader(`Adding Agent: ${title}`);
+  printInfo(`Target: ${resolved.type} (${target})`);
+  printInfo(`Template: ${template}`);
+
+  // Generate agent content
+  const agentContent = generateAgent(name, template, {
+    description: agentDescription,
+    tools,
+  });
+
+  if (dryRun) {
+    console.log('\n[DRY RUN] Would create:\n');
+    console.log(`  📄 ${agentPath}`);
+    console.log(`  📝 Update ${manifestPath}`);
+    console.log('\nAgent content preview:');
+    console.log('─'.repeat(40));
+    console.log(agentContent.slice(0, 500) + '...');
+    console.log('\nRun without --dry-run to create.');
+    process.exit(0);
+  }
+
+  // Create agents directory if needed
+  ensureDir(agentsDir);
+
+  // Write agent file
+  writeFileIfNotExists(agentPath, agentContent, { force: true });
+  printSuccess(`Created ${agentPath}`);
+
+  // Update manifest
+  try {
+    updateManifest(manifestPath, 'agents', kebab);
+    printSuccess(`Updated ${manifestPath}`);
+  } catch (err) {
+    printError(`Could not update manifest: ${err.message}`);
+  }
+
+  // Summary
+  printHeader('Agent Added Successfully');
+  printInfo(`Agent: ${kebab}`);
+  printInfo(`Location: ${agentPath}`);
+  printInfo(`Template: ${template}`);
+  printInfo('');
+  printInfo('Next steps:');
+  printInfo('  1. Edit the agent file to customize expertise and workflow');
+  printInfo('  2. Test the agent in a Claude Code session');
+  console.log('');
+}
+
+main().catch(err => {
+  printError(err.message);
+  process.exit(1);
+});

--- a/tools/scaffolding/add-command.mjs
+++ b/tools/scaffolding/add-command.mjs
@@ -1,0 +1,453 @@
+#!/usr/bin/env node
+
+/**
+ * CLI tool to add a command to an existing addon, framework, or extension
+ * Usage: aiwg add-command <name> --to <target> [options]
+ */
+
+import {
+  parseArgs,
+  formatName,
+  ensureDir,
+  writeFileIfNotExists,
+  updateManifest,
+  resolveTargetPath,
+  printSuccess,
+  printError,
+  printInfo,
+  printHeader,
+  listAddons,
+  listFrameworks,
+} from './utils.mjs';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const { positional, flags } = parseArgs(process.argv);
+
+const name = positional[0];
+const target = flags.to || flags.t;
+const template = flags.template || 'utility';
+const commandDescription = flags.description || flags.d || `${formatName(name || 'command').title} command`;
+const dryRun = flags['dry-run'] || flags.n;
+const help = flags.help || flags.h;
+
+const VALID_TEMPLATES = ['utility', 'transformation', 'orchestration'];
+
+function printHelp() {
+  const addons = listAddons();
+  const frameworks = listFrameworks();
+
+  console.log(`
+Usage: aiwg add-command <name> --to <target> [options]
+
+Add a new slash command to an existing addon, framework, or extension.
+
+Arguments:
+  name                  Command name (kebab-case recommended)
+
+Required:
+  --to, -t              Target addon, framework, or extension path
+
+Options:
+  --template            Command template: utility (default), transformation, orchestration
+  --description, -d     Command description
+  --dry-run, -n         Preview what would be created
+  --help, -h            Show this help
+
+Templates:
+  utility         Simple operation, single action (default)
+  transformation  Content/code transformation pipeline
+  orchestration   Multi-agent workflow coordination
+
+Available Targets:
+  Addons:     ${addons.length > 0 ? addons.join(', ') : '(none)'}
+  Frameworks: ${frameworks.length > 0 ? frameworks.join(', ') : '(none)'}
+  Extensions: <framework>/extensions/<name>
+
+Examples:
+  aiwg add-command lint-fix --to aiwg-utils
+  aiwg add-command security-scan --to sdlc-complete --template transformation
+  aiwg add-command deploy-all --to sdlc-complete --template orchestration
+`);
+}
+
+function generateCommandUtility(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `---
+name: ${kebab}
+description: ${options.description}
+args: [target-path] [--option value]
+---
+
+# ${title}
+
+${options.description}
+
+## Usage
+
+\`\`\`
+/${kebab} [target-path] [options]
+\`\`\`
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| target-path | No | Path to target (default: current directory) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| --option value | Description of option |
+| --dry-run | Preview changes without executing |
+| --verbose | Show detailed output |
+
+## Examples
+
+\`\`\`bash
+# Basic usage
+/${kebab}
+
+# With target path
+/${kebab} ./src
+
+# With options
+/${kebab} --option value --verbose
+\`\`\`
+
+## Execution
+
+1. Validate inputs and options
+2. [Step 2 of execution]
+3. [Step 3 of execution]
+4. Report results
+
+## Output
+
+\`\`\`
+✓ [Action completed]
+  - [Detail 1]
+  - [Detail 2]
+\`\`\`
+`;
+}
+
+function generateCommandTransformation(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `---
+name: ${kebab}
+description: ${options.description}
+args: <input> [--output value] [--format value]
+---
+
+# ${title}
+
+${options.description}
+
+## Usage
+
+\`\`\`
+/${kebab} <input> [options]
+\`\`\`
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| input | Yes | Input file, directory, or content to transform |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| --output | Output location (default: stdout or in-place) |
+| --format | Output format (default: auto-detect) |
+| --dry-run | Preview transformation without applying |
+| --backup | Create backup before modifying files |
+
+## Transformation Pipeline
+
+### Stage 1: Parse Input
+- Read input content
+- Validate format
+- Build internal representation
+
+### Stage 2: Transform
+- Apply transformation rules
+- [Specific transformation step]
+- [Specific transformation step]
+
+### Stage 3: Output
+- Format output according to --format
+- Write to destination
+- Report changes
+
+## Examples
+
+\`\`\`bash
+# Transform file
+/${kebab} input.md
+
+# Transform with output
+/${kebab} input.md --output output.md
+
+# Transform directory
+/${kebab} ./src --format json
+
+# Preview changes
+/${kebab} input.md --dry-run
+\`\`\`
+
+## Output
+
+### Success
+\`\`\`
+✓ Transformed: input.md → output.md
+  - [Change 1]
+  - [Change 2]
+  - [Change 3]
+\`\`\`
+
+### Dry Run
+\`\`\`
+[DRY RUN] Would transform:
+  input.md:
+    - Line 5: [change description]
+    - Line 12: [change description]
+\`\`\`
+`;
+}
+
+function generateCommandOrchestration(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `---
+name: ${kebab}
+description: ${options.description}
+args: [project-directory] [--guidance "text"] [--interactive]
+---
+
+# ${title}
+
+${options.description}
+
+## Usage
+
+\`\`\`
+/${kebab} [project-directory] [options]
+\`\`\`
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| project-directory | No | Project root (default: current directory) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| --guidance "text" | Strategic guidance to influence execution |
+| --interactive | Enable interactive mode with strategic questions |
+| --dry-run | Preview workflow without executing |
+
+## Workflow Overview
+
+This command orchestrates multiple agents to accomplish:
+
+1. [Phase 1 objective]
+2. [Phase 2 objective]
+3. [Phase 3 objective]
+
+## Agent Assignments
+
+| Phase | Agent | Responsibility |
+|-------|-------|----------------|
+| 1 | [primary-author] | Create initial draft |
+| 2 | [reviewer-1] | Review from perspective X |
+| 2 | [reviewer-2] | Review from perspective Y |
+| 3 | [synthesizer] | Merge feedback and finalize |
+
+## Orchestration Pattern
+
+\`\`\`
+Primary Author → Parallel Reviewers → Synthesizer → Archive
+     ↓                ↓                    ↓           ↓
+  Draft v0.1    Reviews (2-4)      Final merge    .aiwg/
+\`\`\`
+
+## Execution Steps
+
+### Phase 1: Initialize
+1. Validate project directory
+2. Create working directories
+3. Gather context from existing artifacts
+
+### Phase 2: Generate
+1. Launch primary author agent
+2. Wait for draft completion
+3. Launch parallel reviewers
+
+### Phase 3: Synthesize
+1. Collect all reviews
+2. Launch synthesizer agent
+3. Produce final artifact
+
+### Phase 4: Archive
+1. Move artifacts to appropriate .aiwg/ directories
+2. Update indexes and traceability
+3. Report completion
+
+## Examples
+
+\`\`\`bash
+# Basic execution
+/${kebab}
+
+# With guidance
+/${kebab} --guidance "Focus on security, SOC2 audit in 3 months"
+
+# Interactive mode
+/${kebab} --interactive
+
+# Preview workflow
+/${kebab} --dry-run
+\`\`\`
+
+## Output
+
+### Progress Updates
+\`\`\`
+✓ Initialized workspaces
+⏳ Phase 1: Generating draft...
+✓ Draft complete (1,245 words)
+⏳ Phase 2: Launching reviewers (3 agents)...
+  ✓ Reviewer 1: APPROVED
+  ✓ Reviewer 2: CONDITIONAL (minor suggestions)
+  ✓ Reviewer 3: APPROVED
+⏳ Phase 3: Synthesizing...
+✓ Final artifact: .aiwg/[category]/[artifact].md
+\`\`\`
+
+### Artifacts Created
+| Artifact | Location |
+|----------|----------|
+| [Artifact 1] | .aiwg/[dir]/[file].md |
+| [Artifact 2] | .aiwg/[dir]/[file].md |
+
+## Error Handling
+
+- **Missing context**: Request additional information before proceeding
+- **Agent failure**: Retry once, then report and offer alternatives
+- **Conflicting reviews**: Flag for human review with analysis
+`;
+}
+
+function generateCommand(name, templateType, options) {
+  switch (templateType) {
+    case 'transformation':
+      return generateCommandTransformation(name, options);
+    case 'orchestration':
+      return generateCommandOrchestration(name, options);
+    case 'utility':
+    default:
+      return generateCommandUtility(name, options);
+  }
+}
+
+async function main() {
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!name) {
+    printError('Command name is required.');
+    printHelp();
+    process.exit(1);
+  }
+
+  if (!target) {
+    printError('Target is required. Use --to <addon|framework|extension>');
+    process.exit(1);
+  }
+
+  if (!VALID_TEMPLATES.includes(template)) {
+    printError(`Invalid template: ${template}. Valid options: ${VALID_TEMPLATES.join(', ')}`);
+    process.exit(1);
+  }
+
+  const { kebab, title } = formatName(name);
+  const resolved = resolveTargetPath(target);
+
+  if (!resolved) {
+    printError(`Target not found: ${target}`);
+    printInfo('Check that the addon, framework, or extension exists.');
+    process.exit(1);
+  }
+
+  const commandsDir = join(resolved.path, 'commands');
+  const commandPath = join(commandsDir, `${kebab}.md`);
+  const manifestPath = join(resolved.path, 'manifest.json');
+
+  // Check if command already exists
+  if (existsSync(commandPath)) {
+    printError(`Command already exists: ${commandPath}`);
+    process.exit(1);
+  }
+
+  printHeader(`Adding Command: /${kebab}`);
+  printInfo(`Target: ${resolved.type} (${target})`);
+  printInfo(`Template: ${template}`);
+
+  // Generate command content
+  const commandContent = generateCommand(name, template, {
+    description: commandDescription,
+  });
+
+  if (dryRun) {
+    console.log('\n[DRY RUN] Would create:\n');
+    console.log(`  📄 ${commandPath}`);
+    console.log(`  📝 Update ${manifestPath}`);
+    console.log('\nCommand content preview:');
+    console.log('─'.repeat(40));
+    console.log(commandContent.slice(0, 500) + '...');
+    console.log('\nRun without --dry-run to create.');
+    process.exit(0);
+  }
+
+  // Create commands directory if needed
+  ensureDir(commandsDir);
+
+  // Write command file
+  writeFileIfNotExists(commandPath, commandContent, { force: true });
+  printSuccess(`Created ${commandPath}`);
+
+  // Update manifest
+  try {
+    updateManifest(manifestPath, 'commands', kebab);
+    printSuccess(`Updated ${manifestPath}`);
+  } catch (err) {
+    printError(`Could not update manifest: ${err.message}`);
+  }
+
+  // Summary
+  printHeader('Command Added Successfully');
+  printInfo(`Command: /${kebab}`);
+  printInfo(`Location: ${commandPath}`);
+  printInfo(`Template: ${template}`);
+  printInfo('');
+  printInfo('Next steps:');
+  printInfo('  1. Edit the command file to customize behavior');
+  printInfo('  2. Deploy and test: aiwg use <framework>');
+  printInfo(`  3. Use in session: /${kebab}`);
+  console.log('');
+}
+
+main().catch(err => {
+  printError(err.message);
+  process.exit(1);
+});

--- a/tools/scaffolding/add-skill.mjs
+++ b/tools/scaffolding/add-skill.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+/**
+ * CLI tool to add a skill to an existing addon or framework
+ * Usage: aiwg add-skill <name> --to <target> [options]
+ */
+
+import {
+  parseArgs,
+  formatName,
+  ensureDir,
+  writeFileIfNotExists,
+  updateManifest,
+  resolveTargetPath,
+  printSuccess,
+  printError,
+  printInfo,
+  printHeader,
+  listAddons,
+  listFrameworks,
+} from './utils.mjs';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const { positional, flags } = parseArgs(process.argv);
+
+const name = positional[0];
+const target = flags.to || flags.t;
+const skillDescription = flags.description || flags.d || `${formatName(name || 'skill').title} skill`;
+const triggers = flags.triggers || '';
+const dryRun = flags['dry-run'] || flags.n;
+const help = flags.help || flags.h;
+
+function printHelp() {
+  const addons = listAddons();
+  const frameworks = listFrameworks();
+
+  console.log(`
+Usage: aiwg add-skill <name> --to <target> [options]
+
+Add a new skill to an existing addon or framework.
+
+Skills are auto-triggered capabilities that activate based on natural language patterns.
+
+Arguments:
+  name                  Skill name (kebab-case recommended)
+
+Required:
+  --to, -t              Target addon or framework
+
+Options:
+  --description, -d     Skill description
+  --triggers            Comma-separated trigger phrases
+  --dry-run, -n         Preview what would be created
+  --help, -h            Show this help
+
+Available Targets:
+  Addons:     ${addons.length > 0 ? addons.join(', ') : '(none)'}
+  Frameworks: ${frameworks.length > 0 ? frameworks.join(', ') : '(none)'}
+
+Examples:
+  aiwg add-skill code-analyzer --to aiwg-utils
+  aiwg add-skill voice-apply --to voice-framework --triggers "use voice,apply voice"
+`);
+}
+
+function generateSkillMd(name, options) {
+  const { kebab, title } = formatName(name);
+  const triggerList = options.triggers
+    ? options.triggers.split(',').map(t => `- "${t.trim()}"`).join('\n')
+    : '- "[trigger phrase 1]"\n- "[trigger phrase 2]"';
+
+  return `---
+name: ${kebab}
+description: ${options.description}
+version: 1.0.0
+---
+
+# ${title} Skill
+
+${options.description}
+
+## Trigger Phrases
+
+This skill activates when the user says:
+
+${triggerList}
+
+## Capability
+
+[Describe what this skill does when triggered]
+
+## Execution Process
+
+1. **Detect**: Recognize trigger phrase in user input
+2. **Parse**: Extract relevant parameters from context
+3. **Execute**: Perform the skill's action
+4. **Report**: Provide results to user
+
+## Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| [param1] | string | [Description] |
+| [param2] | boolean | [Description] |
+
+## Examples
+
+### Example 1: Basic Usage
+\`\`\`
+User: "[trigger phrase] [with context]"
+Skill: [What the skill does]
+\`\`\`
+
+### Example 2: With Options
+\`\`\`
+User: "[trigger phrase] [with options]"
+Skill: [What the skill does differently]
+\`\`\`
+
+## Implementation Notes
+
+- [Technical consideration 1]
+- [Technical consideration 2]
+- [Error handling approach]
+
+## Related Skills
+
+- [related-skill-1]: [How they work together]
+- [related-skill-2]: [How they work together]
+`;
+}
+
+function generateSkillReadme(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `# ${title} Skill
+
+${options.description}
+
+## Files
+
+- \`SKILL.md\` - Skill definition with triggers and execution process
+- \`references/\` - Supporting documentation (optional)
+- \`scripts/\` - Implementation scripts if needed (optional)
+
+## Usage
+
+This skill triggers automatically when the user says one of the trigger phrases defined in SKILL.md.
+
+## Development
+
+1. Edit \`SKILL.md\` to customize triggers and behavior
+2. Add supporting documentation to \`references/\`
+3. Add implementation scripts to \`scripts/\` if needed
+4. Test by deploying and using trigger phrases
+`;
+}
+
+async function main() {
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!name) {
+    printError('Skill name is required.');
+    printHelp();
+    process.exit(1);
+  }
+
+  if (!target) {
+    printError('Target is required. Use --to <addon|framework>');
+    process.exit(1);
+  }
+
+  const { kebab, title } = formatName(name);
+  const resolved = resolveTargetPath(target);
+
+  if (!resolved) {
+    printError(`Target not found: ${target}`);
+    printInfo('Check that the addon or framework exists.');
+    process.exit(1);
+  }
+
+  // Skills typically not added to extensions
+  if (resolved.type === 'extension') {
+    printError('Skills are typically added to addons or frameworks, not extensions.');
+    printInfo('Extensions usually contain templates and checklists.');
+    process.exit(1);
+  }
+
+  const skillsDir = join(resolved.path, 'skills');
+  const skillDir = join(skillsDir, kebab);
+  const skillMdPath = join(skillDir, 'SKILL.md');
+  const readmePath = join(skillDir, 'README.md');
+  const manifestPath = join(resolved.path, 'manifest.json');
+
+  // Check if skill already exists
+  if (existsSync(skillDir)) {
+    printError(`Skill already exists: ${skillDir}`);
+    process.exit(1);
+  }
+
+  printHeader(`Adding Skill: ${title}`);
+  printInfo(`Target: ${resolved.type} (${target})`);
+
+  // Generate content
+  const skillMdContent = generateSkillMd(name, {
+    description: skillDescription,
+    triggers,
+  });
+  const readmeContent = generateSkillReadme(name, {
+    description: skillDescription,
+  });
+
+  if (dryRun) {
+    console.log('\n[DRY RUN] Would create:\n');
+    console.log(`  📁 ${skillDir}/`);
+    console.log(`  📄 ${skillMdPath}`);
+    console.log(`  📄 ${readmePath}`);
+    console.log(`  📁 ${join(skillDir, 'references')}/`);
+    console.log(`  📝 Update ${manifestPath}`);
+    console.log('\nSKILL.md content preview:');
+    console.log('─'.repeat(40));
+    console.log(skillMdContent.slice(0, 500) + '...');
+    console.log('\nRun without --dry-run to create.');
+    process.exit(0);
+  }
+
+  // Create skill directory structure
+  ensureDir(skillDir);
+  ensureDir(join(skillDir, 'references'));
+  printSuccess(`Created ${skillDir}/`);
+
+  // Write SKILL.md
+  writeFileIfNotExists(skillMdPath, skillMdContent, { force: true });
+  printSuccess(`Created ${skillMdPath}`);
+
+  // Write README.md
+  writeFileIfNotExists(readmePath, readmeContent, { force: true });
+  printSuccess(`Created ${readmePath}`);
+
+  // Update manifest
+  try {
+    updateManifest(manifestPath, 'skills', kebab);
+    printSuccess(`Updated ${manifestPath}`);
+  } catch (err) {
+    printError(`Could not update manifest: ${err.message}`);
+  }
+
+  // Summary
+  printHeader('Skill Added Successfully');
+  printInfo(`Skill: ${kebab}`);
+  printInfo(`Location: ${skillDir}/`);
+  printInfo('');
+  printInfo('Next steps:');
+  printInfo('  1. Edit SKILL.md to define trigger phrases');
+  printInfo('  2. Add implementation details');
+  printInfo('  3. Deploy and test: aiwg use <framework>');
+  console.log('');
+}
+
+main().catch(err => {
+  printError(err.message);
+  process.exit(1);
+});

--- a/tools/scaffolding/add-template.mjs
+++ b/tools/scaffolding/add-template.mjs
@@ -1,0 +1,437 @@
+#!/usr/bin/env node
+
+/**
+ * CLI tool to add a template to a framework or extension
+ * Usage: aiwg add-template <name> --to <target> [options]
+ */
+
+import {
+  parseArgs,
+  formatName,
+  ensureDir,
+  writeFileIfNotExists,
+  updateManifest,
+  resolveTargetPath,
+  printSuccess,
+  printError,
+  printInfo,
+  printHeader,
+  listFrameworks,
+} from './utils.mjs';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const { positional, flags } = parseArgs(process.argv);
+
+const name = positional[0];
+const target = flags.to || flags.t;
+const templateType = flags.type || 'document';
+const templateDescription = flags.description || flags.d || `${formatName(name || 'template').title} template`;
+const category = flags.category || flags.c || '';
+const dryRun = flags['dry-run'] || flags.n;
+const help = flags.help || flags.h;
+
+const VALID_TYPES = ['document', 'checklist', 'matrix', 'form'];
+
+function printHelp() {
+  const frameworks = listFrameworks();
+
+  console.log(`
+Usage: aiwg add-template <name> --to <target> [options]
+
+Add a new template to a framework or extension.
+
+Arguments:
+  name                  Template name (kebab-case recommended)
+
+Required:
+  --to, -t              Target framework or extension path
+
+Options:
+  --type                Template type: document (default), checklist, matrix, form
+  --category, -c        Template category/subdirectory (e.g., "security", "compliance")
+  --description, -d     Template description
+  --dry-run, -n         Preview what would be created
+  --help, -h            Show this help
+
+Template Types:
+  document    General document template (default)
+  checklist   Verification checklist with checkboxes
+  matrix      Comparison/mapping matrix with tables
+  form        Intake/collection form with fields
+
+Available Targets:
+  Frameworks:  ${frameworks.length > 0 ? frameworks.join(', ') : '(none)'}
+  Extensions:  <framework>/extensions/<name>
+
+Examples:
+  aiwg add-template security-review --to sdlc-complete --type checklist
+  aiwg add-template hipaa-requirements --to sdlc-complete/extensions/hipaa
+  aiwg add-template control-matrix --to sdlc-complete/extensions/sox --type matrix
+`);
+}
+
+function generateTemplateDocument(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `# ${title}
+
+${options.description}
+
+## Overview
+
+[Provide context and purpose of this document]
+
+## Scope
+
+[Define what is covered and what is not]
+
+## Content
+
+### Section 1: [Topic]
+
+[Content for section 1]
+
+### Section 2: [Topic]
+
+[Content for section 2]
+
+### Section 3: [Topic]
+
+[Content for section 3]
+
+## References
+
+- [Reference 1]
+- [Reference 2]
+
+## Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | YYYY-MM-DD | [Author] | Initial draft |
+
+---
+*Template: ${kebab}*
+`;
+}
+
+function generateTemplateChecklist(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `# ${title} Checklist
+
+${options.description}
+
+## Instructions
+
+Review each item and check when complete. All items must be verified before proceeding.
+
+## Pre-Conditions
+
+- [ ] [Pre-condition 1]
+- [ ] [Pre-condition 2]
+
+## Checklist
+
+### Category 1: [Topic]
+
+- [ ] **Item 1.1**: [Description]
+  - Verification: [How to verify]
+  - Evidence: [What evidence to collect]
+
+- [ ] **Item 1.2**: [Description]
+  - Verification: [How to verify]
+  - Evidence: [What evidence to collect]
+
+### Category 2: [Topic]
+
+- [ ] **Item 2.1**: [Description]
+  - Verification: [How to verify]
+  - Evidence: [What evidence to collect]
+
+- [ ] **Item 2.2**: [Description]
+  - Verification: [How to verify]
+  - Evidence: [What evidence to collect]
+
+### Category 3: [Topic]
+
+- [ ] **Item 3.1**: [Description]
+  - Verification: [How to verify]
+  - Evidence: [What evidence to collect]
+
+## Sign-Off
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Preparer | | | |
+| Reviewer | | | |
+| Approver | | | |
+
+## Notes
+
+[Additional notes and observations]
+
+---
+*Template: ${kebab}*
+`;
+}
+
+function generateTemplateMatrix(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `# ${title} Matrix
+
+${options.description}
+
+## Purpose
+
+[Explain what this matrix tracks/maps]
+
+## Matrix
+
+| ID | [Column 1] | [Column 2] | [Column 3] | [Column 4] | Status |
+|----|------------|------------|------------|------------|--------|
+| 1 | [Value] | [Value] | [Value] | [Value] | ⬜ |
+| 2 | [Value] | [Value] | [Value] | [Value] | ⬜ |
+| 3 | [Value] | [Value] | [Value] | [Value] | ⬜ |
+| 4 | [Value] | [Value] | [Value] | [Value] | ⬜ |
+| 5 | [Value] | [Value] | [Value] | [Value] | ⬜ |
+
+## Status Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Complete/Compliant |
+| ⬜ | Not Started |
+| 🟡 | In Progress |
+| ❌ | Failed/Non-Compliant |
+| N/A | Not Applicable |
+
+## Analysis
+
+### Summary
+
+- Total items: [X]
+- Complete: [X]
+- In Progress: [X]
+- Not Started: [X]
+
+### Findings
+
+[Key findings from the matrix analysis]
+
+### Recommendations
+
+1. [Recommendation 1]
+2. [Recommendation 2]
+
+## Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | YYYY-MM-DD | [Author] | Initial draft |
+
+---
+*Template: ${kebab}*
+`;
+}
+
+function generateTemplateForm(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `# ${title} Form
+
+${options.description}
+
+## Instructions
+
+Complete all required fields (*). Submit to [recipient/process] when complete.
+
+---
+
+## Section 1: Basic Information
+
+**Field 1*** _(required)_:
+
+
+**Field 2*** _(required)_:
+
+
+**Field 3** _(optional)_:
+
+
+---
+
+## Section 2: Details
+
+**Description*** _(required)_:
+
+> [Provide detailed description]
+
+**Category*** _(required)_:
+
+- [ ] Option A
+- [ ] Option B
+- [ ] Option C
+- [ ] Other: _____________
+
+**Priority*** _(required)_:
+
+- [ ] Critical
+- [ ] High
+- [ ] Medium
+- [ ] Low
+
+---
+
+## Section 3: Additional Information
+
+**Supporting Documentation**:
+
+| Document | Attached | Notes |
+|----------|----------|-------|
+| [Doc 1] | ☐ Yes ☐ No | |
+| [Doc 2] | ☐ Yes ☐ No | |
+
+**Comments**:
+
+> [Additional comments or context]
+
+---
+
+## Submission
+
+**Submitted By**: _____________
+
+**Date**: _____________
+
+**Reviewed By**: _____________
+
+**Approval Status**: ☐ Approved ☐ Rejected ☐ Pending
+
+---
+*Template: ${kebab}*
+`;
+}
+
+function generateTemplate(name, type, options) {
+  switch (type) {
+    case 'checklist':
+      return generateTemplateChecklist(name, options);
+    case 'matrix':
+      return generateTemplateMatrix(name, options);
+    case 'form':
+      return generateTemplateForm(name, options);
+    case 'document':
+    default:
+      return generateTemplateDocument(name, options);
+  }
+}
+
+async function main() {
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!name) {
+    printError('Template name is required.');
+    printHelp();
+    process.exit(1);
+  }
+
+  if (!target) {
+    printError('Target is required. Use --to <framework|extension>');
+    process.exit(1);
+  }
+
+  if (!VALID_TYPES.includes(templateType)) {
+    printError(`Invalid type: ${templateType}. Valid options: ${VALID_TYPES.join(', ')}`);
+    process.exit(1);
+  }
+
+  const { kebab, title } = formatName(name);
+  const resolved = resolveTargetPath(target);
+
+  if (!resolved) {
+    printError(`Target not found: ${target}`);
+    printInfo('Check that the framework or extension exists.');
+    process.exit(1);
+  }
+
+  // Templates typically not added to addons
+  if (resolved.type === 'addon') {
+    printError('Templates are typically added to frameworks or extensions, not addons.');
+    printInfo('Addons usually contain agents, commands, and skills.');
+    process.exit(1);
+  }
+
+  // Determine templates directory and path
+  let templatesDir = join(resolved.path, 'templates');
+  if (category) {
+    templatesDir = join(templatesDir, category);
+  }
+  const templatePath = join(templatesDir, `${kebab}.md`);
+  const manifestPath = join(resolved.path, 'manifest.json');
+
+  // Check if template already exists
+  if (existsSync(templatePath)) {
+    printError(`Template already exists: ${templatePath}`);
+    process.exit(1);
+  }
+
+  printHeader(`Adding Template: ${title}`);
+  printInfo(`Target: ${resolved.type} (${target})`);
+  printInfo(`Type: ${templateType}`);
+  if (category) {
+    printInfo(`Category: ${category}`);
+  }
+
+  // Generate template content
+  const templateContent = generateTemplate(name, templateType, {
+    description: templateDescription,
+  });
+
+  if (dryRun) {
+    console.log('\n[DRY RUN] Would create:\n');
+    console.log(`  📄 ${templatePath}`);
+    console.log(`  📝 Update ${manifestPath}`);
+    console.log('\nTemplate content preview:');
+    console.log('─'.repeat(40));
+    console.log(templateContent.slice(0, 500) + '...');
+    console.log('\nRun without --dry-run to create.');
+    process.exit(0);
+  }
+
+  // Create templates directory if needed
+  ensureDir(templatesDir);
+
+  // Write template file
+  writeFileIfNotExists(templatePath, templateContent, { force: true });
+  printSuccess(`Created ${templatePath}`);
+
+  // Update manifest
+  try {
+    updateManifest(manifestPath, 'templates', category ? `${category}/${kebab}` : kebab);
+    printSuccess(`Updated ${manifestPath}`);
+  } catch (err) {
+    printError(`Could not update manifest: ${err.message}`);
+  }
+
+  // Summary
+  printHeader('Template Added Successfully');
+  printInfo(`Template: ${kebab}`);
+  printInfo(`Location: ${templatePath}`);
+  printInfo(`Type: ${templateType}`);
+  printInfo('');
+  printInfo('Next steps:');
+  printInfo('  1. Edit the template to customize content');
+  printInfo('  2. Reference in workflows and documentation');
+  console.log('');
+}
+
+main().catch(err => {
+  printError(err.message);
+  process.exit(1);
+});

--- a/tools/scaffolding/scaffold-addon.mjs
+++ b/tools/scaffolding/scaffold-addon.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+
+/**
+ * CLI tool to scaffold a new AIWG addon
+ * Usage: aiwg scaffold-addon <name> [options]
+ */
+
+import {
+  parseArgs,
+  formatName,
+  ensureDir,
+  writeFileIfNotExists,
+  writeJson,
+  getAddonsPath,
+  printSuccess,
+  printError,
+  printInfo,
+  printHeader,
+  detectAiwgPath,
+} from './utils.mjs';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const { positional, flags } = parseArgs(process.argv);
+
+const name = positional[0];
+const description = flags.description || flags.d || `${formatName(name || 'addon').title} addon`;
+const author = flags.author || flags.a || '';
+const isCore = flags.core === true || flags.core === 'true';
+const autoInstall = flags['auto-install'] === true || flags['auto-install'] === 'true';
+const dryRun = flags['dry-run'] || flags.n;
+const help = flags.help || flags.h;
+
+function printHelp() {
+  console.log(`
+Usage: aiwg scaffold-addon <name> [options]
+
+Create a new AIWG addon with standard directory structure.
+
+Arguments:
+  name                  Addon name (kebab-case recommended)
+
+Options:
+  --description, -d     Addon description
+  --author, -a          Author name
+  --core                Mark as core addon (auto-installed with frameworks)
+  --auto-install        Auto-install with any framework
+  --dry-run, -n         Preview what would be created
+  --help, -h            Show this help
+
+Examples:
+  aiwg scaffold-addon my-utils
+  aiwg scaffold-addon code-metrics --description "Code quality metrics"
+  aiwg scaffold-addon security-scanner --author "Jane Doe" --dry-run
+
+Creates:
+  agentic/code/addons/<name>/
+  ├── manifest.json
+  ├── README.md
+  ├── agents/
+  ├── commands/
+  └── skills/
+`);
+}
+
+function generateManifest(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return {
+    id: kebab,
+    type: 'addon',
+    name: title,
+    version: '1.0.0',
+    description: options.description,
+    author: options.author || undefined,
+    core: options.isCore || undefined,
+    autoInstall: options.autoInstall || undefined,
+    entry: {
+      agents: 'agents',
+      commands: 'commands',
+      skills: 'skills',
+    },
+    agents: [],
+    commands: [],
+    skills: [],
+  };
+}
+
+function generateReadme(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return `# ${title}
+
+${options.description}
+
+## Installation
+
+This addon is automatically deployed with AIWG frameworks, or can be deployed standalone:
+
+\`\`\`bash
+aiwg -deploy-agents --source agentic/code/addons/${kebab} --deploy-commands --deploy-skills
+\`\`\`
+
+## Contents
+
+### Agents
+
+| Agent | Description |
+|-------|-------------|
+| (none yet) | Add agents with \`aiwg add-agent <name> --to ${kebab}\` |
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| (none yet) | Add commands with \`aiwg add-command <name> --to ${kebab}\` |
+
+### Skills
+
+| Skill | Description |
+|-------|-------------|
+| (none yet) | Add skills with \`aiwg add-skill <name> --to ${kebab}\` |
+
+## Development
+
+### Add Components
+
+\`\`\`bash
+# Add a new agent
+aiwg add-agent my-agent --to ${kebab} --template simple
+
+# Add a new command
+aiwg add-command my-command --to ${kebab} --template utility
+
+# Add a new skill
+aiwg add-skill my-skill --to ${kebab}
+\`\`\`
+
+### Validate
+
+\`\`\`bash
+aiwg validate agentic/code/addons/${kebab}
+\`\`\`
+
+## License
+
+See repository LICENSE file.
+`;
+}
+
+async function main() {
+  if (help || !name) {
+    printHelp();
+    process.exit(help ? 0 : 1);
+  }
+
+  const { kebab, title } = formatName(name);
+  const aiwgPath = detectAiwgPath();
+
+  if (!aiwgPath) {
+    printError('AIWG installation not found. Set AIWG_ROOT environment variable.');
+    process.exit(1);
+  }
+
+  const addonsPath = getAddonsPath();
+  const addonPath = join(addonsPath, kebab);
+
+  // Check if addon already exists
+  if (existsSync(addonPath)) {
+    printError(`Addon already exists: ${addonPath}`);
+    process.exit(1);
+  }
+
+  printHeader(`Scaffolding Addon: ${title}`);
+
+  const filesToCreate = [
+    { path: join(addonPath, 'manifest.json'), content: null, type: 'json' },
+    { path: join(addonPath, 'README.md'), content: null, type: 'text' },
+  ];
+
+  const dirsToCreate = [
+    join(addonPath, 'agents'),
+    join(addonPath, 'commands'),
+    join(addonPath, 'skills'),
+  ];
+
+  // Generate content
+  const manifest = generateManifest(name, { description, author, isCore, autoInstall });
+  const readme = generateReadme(name, { description });
+
+  filesToCreate[0].content = manifest;
+  filesToCreate[1].content = readme;
+
+  if (dryRun) {
+    console.log('\n[DRY RUN] Would create:\n');
+    for (const dir of dirsToCreate) {
+      console.log(`  📁 ${dir}/`);
+    }
+    for (const file of filesToCreate) {
+      console.log(`  📄 ${file.path}`);
+    }
+    console.log('\nRun without --dry-run to create.');
+    process.exit(0);
+  }
+
+  // Create directories
+  for (const dir of dirsToCreate) {
+    ensureDir(dir);
+    printSuccess(`Created ${dir}/`);
+  }
+
+  // Create files
+  for (const file of filesToCreate) {
+    if (file.type === 'json') {
+      writeJson(file.path, file.content);
+    } else {
+      writeFileIfNotExists(file.path, file.content, { force: true });
+    }
+    printSuccess(`Created ${file.path}`);
+  }
+
+  // Summary
+  printHeader('Addon Created Successfully');
+  printInfo(`Location: ${addonPath}`);
+  printInfo('');
+  printInfo('Next steps:');
+  printInfo(`  1. Add agents:   aiwg add-agent <name> --to ${kebab}`);
+  printInfo(`  2. Add commands: aiwg add-command <name> --to ${kebab}`);
+  printInfo(`  3. Add skills:   aiwg add-skill <name> --to ${kebab}`);
+  printInfo(`  4. Deploy:       aiwg -deploy-agents --source agentic/code/addons/${kebab}`);
+  console.log('');
+}
+
+main().catch(err => {
+  printError(err.message);
+  process.exit(1);
+});

--- a/tools/scaffolding/scaffold-extension.mjs
+++ b/tools/scaffolding/scaffold-extension.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+
+/**
+ * CLI tool to scaffold a new AIWG extension (framework expansion pack)
+ * Usage: aiwg scaffold-extension <name> --for <framework> [options]
+ */
+
+import {
+  parseArgs,
+  formatName,
+  ensureDir,
+  writeFileIfNotExists,
+  writeJson,
+  getFrameworksPath,
+  listFrameworks,
+  printSuccess,
+  printError,
+  printInfo,
+  printHeader,
+  detectAiwgPath,
+} from './utils.mjs';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const { positional, flags } = parseArgs(process.argv);
+
+const name = positional[0];
+const framework = flags.for || flags.f;
+const description = flags.description || flags.d || `${formatName(name || 'extension').title} extension`;
+const author = flags.author || flags.a || '';
+const dryRun = flags['dry-run'] || flags.n;
+const help = flags.help || flags.h;
+
+function printHelp() {
+  const frameworks = listFrameworks();
+  const frameworkList = frameworks.length > 0 ? frameworks.join(', ') : '(none found)';
+
+  console.log(`
+Usage: aiwg scaffold-extension <name> --for <framework> [options]
+
+Create a new AIWG extension (framework expansion pack).
+
+Extensions enhance a specific parent framework with additional templates,
+checklists, and domain-specific content. They cannot operate standalone.
+
+Arguments:
+  name                  Extension name (kebab-case recommended)
+
+Required:
+  --for, -f             Parent framework ID (required)
+
+Options:
+  --description, -d     Extension description
+  --author, -a          Author name
+  --dry-run, -n         Preview what would be created
+  --help, -h            Show this help
+
+Available Frameworks: ${frameworkList}
+
+Examples:
+  aiwg scaffold-extension hipaa --for sdlc-complete
+  aiwg scaffold-extension gdpr --for sdlc-complete --description "GDPR compliance templates"
+  aiwg scaffold-extension ftc --for media-marketing-kit --author "Legal Team"
+
+Creates:
+  agentic/code/frameworks/<framework>/extensions/<name>/
+  ├── manifest.json      # type: "extension", requires: ["<framework>"]
+  ├── README.md
+  ├── templates/
+  └── checklists/
+`);
+}
+
+function generateManifest(name, options) {
+  const { kebab, title } = formatName(name);
+
+  return {
+    id: kebab,
+    type: 'extension',
+    name: title,
+    version: '1.0.0',
+    description: options.description,
+    requires: [options.framework],
+    author: options.author || undefined,
+    entry: {
+      templates: 'templates',
+      checklists: 'checklists',
+    },
+    templates: [],
+    checklists: [],
+  };
+}
+
+function generateReadme(name, options) {
+  const { kebab, title } = formatName(name);
+  const { title: frameworkTitle } = formatName(options.framework);
+
+  return `# ${title} Extension
+
+${options.description}
+
+## Overview
+
+This extension enhances the **${frameworkTitle}** framework with additional templates and checklists for ${title.toLowerCase()} requirements.
+
+## Requirements
+
+- Parent framework: \`${options.framework}\`
+
+This extension cannot operate standalone. Install the parent framework first:
+
+\`\`\`bash
+aiwg use ${options.framework.includes('marketing') ? 'marketing' : 'sdlc'}
+\`\`\`
+
+## Contents
+
+### Templates
+
+| Template | Description |
+|----------|-------------|
+| (none yet) | Add templates with \`aiwg add-template <name> --to ${options.framework}/extensions/${kebab}\` |
+
+### Checklists
+
+| Checklist | Description |
+|-----------|-------------|
+| (none yet) | Add manually to \`checklists/\` directory |
+
+## Usage
+
+Once the parent framework is deployed, this extension's templates are available in the framework's template library.
+
+### In Claude Code
+
+Reference templates in prompts:
+\`\`\`
+Use the ${kebab} templates for compliance requirements...
+\`\`\`
+
+### Manually
+
+Copy templates from:
+\`\`\`
+agentic/code/frameworks/${options.framework}/extensions/${kebab}/templates/
+\`\`\`
+
+## Development
+
+### Add Templates
+
+\`\`\`bash
+aiwg add-template compliance-matrix --to ${options.framework}/extensions/${kebab}
+aiwg add-template audit-checklist --to ${options.framework}/extensions/${kebab}
+\`\`\`
+
+### Validate
+
+\`\`\`bash
+aiwg validate agentic/code/frameworks/${options.framework}/extensions/${kebab}
+\`\`\`
+
+## License
+
+See repository LICENSE file.
+`;
+}
+
+async function main() {
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!name) {
+    printError('Extension name is required.');
+    printHelp();
+    process.exit(1);
+  }
+
+  if (!framework) {
+    printError('Parent framework is required. Use --for <framework>');
+    const frameworks = listFrameworks();
+    if (frameworks.length > 0) {
+      printInfo(`Available frameworks: ${frameworks.join(', ')}`);
+    }
+    process.exit(1);
+  }
+
+  const { kebab, title } = formatName(name);
+  const aiwgPath = detectAiwgPath();
+
+  if (!aiwgPath) {
+    printError('AIWG installation not found. Set AIWG_ROOT environment variable.');
+    process.exit(1);
+  }
+
+  // Validate parent framework exists
+  const frameworksPath = getFrameworksPath();
+  const frameworkPath = join(frameworksPath, framework);
+
+  if (!existsSync(join(frameworkPath, 'manifest.json'))) {
+    printError(`Framework not found: ${framework}`);
+    const frameworks = listFrameworks();
+    if (frameworks.length > 0) {
+      printInfo(`Available frameworks: ${frameworks.join(', ')}`);
+    }
+    process.exit(1);
+  }
+
+  // Extension path
+  const extensionPath = join(frameworkPath, 'extensions', kebab);
+
+  // Check if extension already exists
+  if (existsSync(extensionPath)) {
+    printError(`Extension already exists: ${extensionPath}`);
+    process.exit(1);
+  }
+
+  printHeader(`Scaffolding Extension: ${title}`);
+  printInfo(`Parent framework: ${framework}`);
+
+  const filesToCreate = [
+    { path: join(extensionPath, 'manifest.json'), content: null, type: 'json' },
+    { path: join(extensionPath, 'README.md'), content: null, type: 'text' },
+  ];
+
+  const dirsToCreate = [
+    join(extensionPath, 'templates'),
+    join(extensionPath, 'checklists'),
+  ];
+
+  // Generate content
+  const manifest = generateManifest(name, { description, author, framework });
+  const readme = generateReadme(name, { description, framework });
+
+  filesToCreate[0].content = manifest;
+  filesToCreate[1].content = readme;
+
+  if (dryRun) {
+    console.log('\n[DRY RUN] Would create:\n');
+    for (const dir of dirsToCreate) {
+      console.log(`  📁 ${dir}/`);
+    }
+    for (const file of filesToCreate) {
+      console.log(`  📄 ${file.path}`);
+    }
+    console.log('\nRun without --dry-run to create.');
+    process.exit(0);
+  }
+
+  // Create extensions directory in framework if needed
+  ensureDir(join(frameworkPath, 'extensions'));
+
+  // Create directories
+  for (const dir of dirsToCreate) {
+    ensureDir(dir);
+    printSuccess(`Created ${dir}/`);
+  }
+
+  // Create files
+  for (const file of filesToCreate) {
+    if (file.type === 'json') {
+      writeJson(file.path, file.content);
+    } else {
+      writeFileIfNotExists(file.path, file.content, { force: true });
+    }
+    printSuccess(`Created ${file.path}`);
+  }
+
+  // Summary
+  printHeader('Extension Created Successfully');
+  printInfo(`Location: ${extensionPath}`);
+  printInfo(`Parent:   ${framework}`);
+  printInfo('');
+  printInfo('Next steps:');
+  printInfo(`  1. Add templates:  aiwg add-template <name> --to ${framework}/extensions/${kebab}`);
+  printInfo(`  2. Add checklists: Create files in ${extensionPath}/checklists/`);
+  printInfo(`  3. Deploy parent:  aiwg use ${framework.includes('marketing') ? 'marketing' : 'sdlc'}`);
+  console.log('');
+}
+
+main().catch(err => {
+  printError(err.message);
+  process.exit(1);
+});

--- a/tools/scaffolding/utils.mjs
+++ b/tools/scaffolding/utils.mjs
@@ -1,0 +1,360 @@
+/**
+ * Shared utilities for AIWG scaffolding tools
+ */
+
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 'fs';
+import { join, dirname, basename, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Detect AIWG installation path with multiple fallbacks
+ */
+export function detectAiwgPath() {
+  // 1. Environment variable
+  if (process.env.AIWG_ROOT && existsSync(process.env.AIWG_ROOT)) {
+    return process.env.AIWG_ROOT;
+  }
+
+  // 2. Standard install location
+  const standardPath = join(process.env.HOME || '', '.local/share/ai-writing-guide');
+  if (existsSync(standardPath)) {
+    return standardPath;
+  }
+
+  // 3. Source repo (development mode) - relative to this file
+  const repoRoot = resolve(__dirname, '../..');
+  if (existsSync(join(repoRoot, 'agentic/code'))) {
+    return repoRoot;
+  }
+
+  // 4. Current working directory
+  if (existsSync(join(process.cwd(), 'agentic/code'))) {
+    return process.cwd();
+  }
+
+  return null;
+}
+
+/**
+ * Get path to devkit templates
+ */
+export function getTemplatesPath() {
+  const aiwgPath = detectAiwgPath();
+  if (!aiwgPath) {
+    throw new Error('AIWG installation not found. Set AIWG_ROOT or install AIWG.');
+  }
+  return join(aiwgPath, 'agentic/code/addons/aiwg-utils/templates/devkit');
+}
+
+/**
+ * Get path to frameworks directory
+ */
+export function getFrameworksPath() {
+  const aiwgPath = detectAiwgPath();
+  if (!aiwgPath) {
+    throw new Error('AIWG installation not found.');
+  }
+  return join(aiwgPath, 'agentic/code/frameworks');
+}
+
+/**
+ * Get path to addons directory
+ */
+export function getAddonsPath() {
+  const aiwgPath = detectAiwgPath();
+  if (!aiwgPath) {
+    throw new Error('AIWG installation not found.');
+  }
+  return join(aiwgPath, 'agentic/code/addons');
+}
+
+/**
+ * Ensure directory exists, creating recursively if needed
+ */
+export function ensureDir(dirPath) {
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true });
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Write file if it doesn't exist (non-destructive)
+ */
+export function writeFileIfNotExists(filePath, content, options = {}) {
+  const { force = false } = options;
+  if (existsSync(filePath) && !force) {
+    return { written: false, reason: 'exists' };
+  }
+  ensureDir(dirname(filePath));
+  writeFileSync(filePath, content, 'utf8');
+  return { written: true };
+}
+
+/**
+ * Read and parse JSON file
+ */
+export function readJson(filePath) {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+/**
+ * Write JSON file with consistent formatting
+ */
+export function writeJson(filePath, data) {
+  ensureDir(dirname(filePath));
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
+
+/**
+ * Update manifest.json to add a component
+ */
+export function updateManifest(manifestPath, componentType, componentName) {
+  const manifest = readJson(manifestPath);
+  if (!manifest) {
+    throw new Error(`Manifest not found: ${manifestPath}`);
+  }
+
+  // Ensure array exists
+  if (!Array.isArray(manifest[componentType])) {
+    manifest[componentType] = [];
+  }
+
+  // Add if not present
+  if (!manifest[componentType].includes(componentName)) {
+    manifest[componentType].push(componentName);
+    manifest[componentType].sort(); // Alphabetical order
+  }
+
+  writeJson(manifestPath, manifest);
+  return manifest;
+}
+
+/**
+ * Convert name to various formats
+ */
+export function formatName(name) {
+  // Normalize to kebab-case
+  const kebab = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  // Title case
+  const title = kebab
+    .split('-')
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+
+  // PascalCase
+  const pascal = kebab
+    .split('-')
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join('');
+
+  // camelCase
+  const camel = pascal.charAt(0).toLowerCase() + pascal.slice(1);
+
+  return { kebab, title, pascal, camel };
+}
+
+/**
+ * Simple template substitution
+ */
+export function substituteTemplate(template, vars) {
+  let result = template;
+  for (const [key, value] of Object.entries(vars)) {
+    const regex = new RegExp(`\\{\\{\\s*${key}\\s*\\}\\}`, 'g');
+    result = result.replace(regex, value);
+  }
+  return result;
+}
+
+/**
+ * Load template file from devkit templates
+ */
+export function loadTemplate(templateName) {
+  const templatesPath = getTemplatesPath();
+  const templatePath = join(templatesPath, templateName);
+
+  if (!existsSync(templatePath)) {
+    return null;
+  }
+
+  return readFileSync(templatePath, 'utf8');
+}
+
+/**
+ * List available frameworks
+ */
+export function listFrameworks() {
+  const frameworksPath = getFrameworksPath();
+  if (!existsSync(frameworksPath)) {
+    return [];
+  }
+
+  return readdirSync(frameworksPath, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => d.name)
+    .filter(name => existsSync(join(frameworksPath, name, 'manifest.json')));
+}
+
+/**
+ * List available addons
+ */
+export function listAddons() {
+  const addonsPath = getAddonsPath();
+  if (!existsSync(addonsPath)) {
+    return [];
+  }
+
+  return readdirSync(addonsPath, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => d.name)
+    .filter(name => existsSync(join(addonsPath, name, 'manifest.json')));
+}
+
+/**
+ * Resolve target path (addon, framework, or extension)
+ */
+export function resolveTargetPath(target) {
+  // Check if it's a path to extension (framework/extensions/name)
+  if (target.includes('/extensions/')) {
+    const frameworksPath = getFrameworksPath();
+    const fullPath = join(frameworksPath, target);
+    if (existsSync(fullPath)) {
+      return { type: 'extension', path: fullPath, target };
+    }
+    // Check if parent framework exists (for creating new extensions)
+    const parts = target.split('/extensions/');
+    const frameworkPath = join(frameworksPath, parts[0]);
+    if (existsSync(frameworkPath)) {
+      return { type: 'extension', path: fullPath, target, frameworkPath };
+    }
+  }
+
+  // Check frameworks
+  const frameworksPath = getFrameworksPath();
+  const frameworkPath = join(frameworksPath, target);
+  if (existsSync(join(frameworkPath, 'manifest.json'))) {
+    return { type: 'framework', path: frameworkPath, target };
+  }
+
+  // Check addons
+  const addonsPath = getAddonsPath();
+  const addonPath = join(addonsPath, target);
+  if (existsSync(join(addonPath, 'manifest.json'))) {
+    return { type: 'addon', path: addonPath, target };
+  }
+
+  return null;
+}
+
+/**
+ * Parse CLI arguments
+ */
+export function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = {
+    positional: [],
+    flags: {},
+  };
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      // Check if next arg is a value or another flag
+      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        result.flags[key] = args[i + 1];
+        i += 2;
+      } else {
+        result.flags[key] = true;
+        i += 1;
+      }
+    } else if (arg.startsWith('-') && arg.length === 2) {
+      const key = arg.slice(1);
+      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        result.flags[key] = args[i + 1];
+        i += 2;
+      } else {
+        result.flags[key] = true;
+        i += 1;
+      }
+    } else {
+      result.positional.push(arg);
+      i += 1;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Print success message
+ */
+export function printSuccess(message) {
+  console.log(`✓ ${message}`);
+}
+
+/**
+ * Print error message
+ */
+export function printError(message) {
+  console.error(`✗ ${message}`);
+}
+
+/**
+ * Print info message
+ */
+export function printInfo(message) {
+  console.log(`  ${message}`);
+}
+
+/**
+ * Print section header
+ */
+export function printHeader(title) {
+  console.log(`\n${title}`);
+  console.log('─'.repeat(title.length));
+}
+
+/**
+ * Generate timestamp for filenames
+ */
+export function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+}
+
+/**
+ * Validate manifest has required fields
+ */
+export function validateManifest(manifest, type = 'addon') {
+  const errors = [];
+
+  const requiredFields = ['id', 'type', 'name', 'version', 'description'];
+  for (const field of requiredFields) {
+    if (!manifest[field]) {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+
+  if (manifest.type !== type) {
+    errors.push(`Expected type '${type}', got '${manifest.type}'`);
+  }
+
+  if (type === 'extension' && !manifest.requires) {
+    errors.push("Extension must have 'requires' field specifying parent framework");
+  }
+
+  return errors;
+}


### PR DESCRIPTION
Complete Phase 1 implementation of the AIWG Development Kit, enabling users to easily create and extend addons, frameworks, and extensions.

CLI Scaffolding Tools (tools/scaffolding/):
- scaffold-addon.mjs: Create new addon structure
- scaffold-extension.mjs: Create framework expansion packs
- add-agent.mjs: Add agent with simple/complex/orchestrator templates
- add-command.mjs: Add command with utility/transformation/orchestration templates
- add-skill.mjs: Add skill with trigger phrase support
- add-template.mjs: Add template with document/checklist/matrix/form types
- utils.mjs: Shared utilities (path detection, manifest updates, formatting)

In-Session Commands (agentic/code/addons/aiwg-utils/commands/):
- devkit-create-addon: Interactive addon creation
- devkit-create-extension: Interactive extension creation
- devkit-create-agent: Interactive agent creation
- devkit-create-command: Interactive command creation
- devkit-validate: Validate addon/framework/extension structure

Agent (agentic/code/addons/aiwg-utils/agents/):
- aiwg-developer: Expert in AIWG architecture and development patterns

Templates (agentic/code/addons/aiwg-utils/templates/devkit/):
- addon-manifest.json: Addon manifest template
- framework-manifest.json: Framework manifest template
- extension-manifest.json: Extension manifest with requires field

Integration:
- Updated install.sh with scaffold-*, add-*, validate commands
- Updated aiwg-utils manifest.json to v1.2.0
- Added templates entry point to manifest

Three-tier taxonomy supported per ADR-008:
- Tier 1: Frameworks (complete lifecycle solutions)
- Tier 2: Addons (standalone utilities)
- Tier 3: Extensions (framework expansion packs)

Usage:
  aiwg scaffold-addon my-utils aiwg scaffold-extension hipaa --for sdlc-complete aiwg add-agent reviewer --to my-utils --template complex aiwg add-command lint-fix --to my-utils --template transformation