### PR TITLE
feat: implement OpenCode provider integration

### DIFF
--- a/.aiwg/planning/opencode-integration-plan.md
+++ b/.aiwg/planning/opencode-integration-plan.md
@@ -1,0 +1,588 @@
+# OpenCode Integration Plan
+
+## Overview
+
+This document outlines the integration strategy for AIWG with [OpenCode](https://opencode.ai), the open-source AI coding agent from SST.
+
+**Status**: ✅ COMPLETE
+**Priority**: P1 - High
+**Completed**: 2025-12-11
+
+## OpenCode Feature Summary
+
+OpenCode is feature-rich with capabilities we should fully leverage:
+
+| Feature | Description | AIWG Integration |
+|---------|-------------|------------------|
+| **Agents** | Primary + subagent system with @mentions | Deploy SDLC agents as subagents |
+| **Commands** | Custom slash commands with templates | Convert AIWG commands to /commands |
+| **MCP Servers** | Local and remote MCP support | Deploy AIWG MCP server |
+| **Custom Tools** | TypeScript/JavaScript tool definitions | Create AIWG workflow tools |
+| **Plugins** | Event hooks and custom behaviors | Create AIWG plugin for automation |
+| **GitHub Integration** | /opencode in issues/PRs | Provide GitHub workflow template |
+| **LSP Support** | Built-in language servers | Leverage for code quality |
+| **Themes** | Custom JSON themes | Provide AIWG theme |
+| **Formatters** | Auto-formatting support | Document integration |
+| **Permissions** | Granular tool/bash permissions | Configure SDLC-appropriate defaults |
+| **instructions** | Multi-file instruction loading | Use for SDLC artifact references |
+
+## Directory Structure
+
+```
+.opencode/
+├── agent/           # AIWG SDLC agents (subagents)
+│   ├── security-architect.md
+│   ├── test-engineer.md
+│   ├── requirements-analyst.md
+│   └── ...
+├── command/         # AIWG slash commands
+│   ├── security-audit.md
+│   ├── generate-tests.md
+│   ├── flow-gate-check.md
+│   └── ...
+├── tool/            # Custom AIWG tools
+│   └── aiwg-workflow.ts
+├── plugin/          # AIWG plugin for automation
+│   └── aiwg-hooks.ts
+├── themes/          # Optional AIWG theme
+│   └── aiwg.json
+└── opencode.jsonc   # Configuration (can also be at project root)
+
+AGENTS.md            # Project context (OpenCode reads natively)
+.aiwg/               # SDLC artifacts
+```
+
+## Integration Components
+
+### 1. Agent Deployment (`.opencode/agent/`)
+
+**Convert AIWG agents to OpenCode subagent format.**
+
+OpenCode agent features to use:
+- `mode: subagent` - All SDLC agents as invokable subagents
+- `mode: primary` - Optional primary "sdlc" agent for orchestration
+- `description` - For agent discovery and auto-invocation
+- `model` - Per-agent model selection
+- `temperature` - Task-appropriate settings (low for analysis, medium for generation)
+- `tools` - Granular tool enable/disable per agent
+- `permission` - Per-agent permission overrides
+- `maxSteps` - Limit iterations for cost control
+
+**OpenCode Agent Format:**
+```markdown
+---
+description: Performs security analysis and identifies vulnerabilities
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.2
+maxSteps: 50
+tools:
+  write: false
+  edit: false
+  bash: true
+  webfetch: true
+permission:
+  bash:
+    "git *": allow
+    "npm audit": allow
+    "*": ask
+---
+
+You are a security expert. Focus on identifying potential security issues.
+
+Look for:
+- Input validation vulnerabilities
+- Authentication and authorization flaws
+- Data exposure risks
+- Dependency vulnerabilities
+- Configuration security issues
+```
+
+**Model Mapping:**
+| AIWG Model | OpenCode Model ID |
+|------------|-------------------|
+| `sonnet` | `anthropic/claude-sonnet-4-20250514` |
+| `opus` | `anthropic/claude-opus-4-20250514` |
+| `haiku` | `anthropic/claude-haiku-4-20250514` |
+
+**Tool Mapping per Agent Type:**
+| Agent Category | Tools Enabled | Tools Disabled |
+|----------------|---------------|----------------|
+| Analysis (security, review) | read, grep, glob, bash, webfetch | write, edit, patch |
+| Implementation (software, test) | ALL | - |
+| Documentation (writer, archivist) | read, write, edit, grep, glob | bash |
+| Planning (requirements, architect) | read, grep, glob, webfetch | write, edit, bash |
+
+### 2. Command Deployment (`.opencode/command/`)
+
+**Convert AIWG commands to OpenCode command format.**
+
+OpenCode command features to use:
+- `description` - For command discovery in TUI
+- `agent` - Route to specific agent (e.g., security commands → security-architect)
+- `model` - Override model for specific commands
+- `subtask` - Force subagent execution to avoid context pollution
+- `$ARGUMENTS` - Pass user input to command template
+- `$1, $2, ...` - Positional arguments
+- `` !`command` `` - Inject shell output into prompt
+- `@filepath` - Include file references
+
+**OpenCode Command Format:**
+```markdown
+---
+description: Run comprehensive security audit
+agent: security-architect
+model: anthropic/claude-sonnet-4-20250514
+subtask: true
+---
+
+Perform a comprehensive security review of this codebase.
+
+Current git status:
+!`git status -s`
+
+Focus areas:
+1. Injection vulnerabilities (SQL, command, XSS)
+2. Authentication and authorization issues
+3. Sensitive data exposure
+4. Security misconfigurations
+5. Cryptographic failures
+6. Insecure dependencies
+
+Check NPM audit:
+!`npm audit --json 2>/dev/null || echo "No npm project"`
+
+For each finding, provide severity, location, description, and fix.
+
+$ARGUMENTS
+```
+
+**Command Categories to Deploy:**
+- Flow commands (gate-check, phase transitions)
+- Review commands (security-audit, pr-review)
+- Generation commands (generate-tests, deploy-gen)
+- Analysis commands (project-status, health-check)
+
+### 3. Custom Tools (`.opencode/tool/`)
+
+**Create TypeScript tools for AIWG-specific operations.**
+
+```typescript
+// .opencode/tool/aiwg-workflow.ts
+import { tool } from "@opencode-ai/plugin"
+
+export const status = tool({
+  description: "Get current AIWG project status and phase",
+  args: {},
+  async execute(args, context) {
+    const { $ } = context
+    const result = await $`aiwg -status`.text()
+    return result
+  },
+})
+
+export const artifact = tool({
+  description: "Read an AIWG artifact from .aiwg/ directory",
+  args: {
+    path: tool.schema.string().describe("Path relative to .aiwg/"),
+  },
+  async execute(args, context) {
+    const { $ } = context
+    const result = await $`cat .aiwg/${args.path}`.text()
+    return result
+  },
+})
+
+export const template = tool({
+  description: "Render an AIWG template",
+  args: {
+    template: tool.schema.string().describe("Template name"),
+    variables: tool.schema.record(tool.schema.string()).optional(),
+  },
+  async execute(args, context) {
+    const { $ } = context
+    const vars = args.variables
+      ? Object.entries(args.variables).map(([k,v]) => `--var ${k}="${v}"`).join(' ')
+      : ''
+    const result = await $`aiwg template render ${args.template} ${vars}`.text()
+    return result
+  },
+})
+
+export const gate = tool({
+  description: "Check SDLC phase gate readiness",
+  args: {
+    phase: tool.schema.string().describe("Phase to check (inception, elaboration, construction, transition)"),
+  },
+  async execute(args, context) {
+    const { $ } = context
+    const result = await $`aiwg gate check ${args.phase}`.text()
+    return result
+  },
+})
+```
+
+### 4. Plugin Integration (`.opencode/plugin/`)
+
+**Create AIWG plugin for automation and event hooks.**
+
+```typescript
+// .opencode/plugin/aiwg-hooks.ts
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const AIWGPlugin: Plugin = async ({ project, client, $, directory }) => {
+  console.log("AIWG Plugin initialized for:", directory)
+
+  return {
+    // Notify on session completion
+    event: async ({ event }) => {
+      if (event.type === "session.idle") {
+        // Log completed session to .aiwg/logs/
+        await $`echo "Session completed: $(date)" >> .aiwg/logs/sessions.log`
+      }
+    },
+
+    // Track file changes for traceability
+    "file.edited": async (input, output) => {
+      const { filePath } = output
+      if (filePath.startsWith("src/") || filePath.startsWith("test/")) {
+        // Could update traceability matrix
+        console.log(`AIWG: File edited - ${filePath}`)
+      }
+    },
+
+    // Protect SDLC artifacts from accidental deletion
+    "tool.execute.before": async (input, output) => {
+      if (input.tool === "bash") {
+        const cmd = output.args.command || ""
+        if (cmd.includes("rm -rf .aiwg")) {
+          throw new Error("Cannot delete .aiwg directory - use /workspace-reset command instead")
+        }
+      }
+    },
+  }
+}
+```
+
+### 5. MCP Server Configuration
+
+**Configure AIWG MCP server in opencode.json.**
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "aiwg": {
+      "type": "local",
+      "command": ["aiwg", "mcp", "serve"],
+      "enabled": true,
+      "timeout": 10000
+    }
+  }
+}
+```
+
+### 6. GitHub Integration
+
+**Provide GitHub Actions workflow template.**
+
+```yaml
+# .github/workflows/opencode-aiwg.yml
+name: OpenCode AIWG
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install AIWG
+        run: npm install -g aiwg
+
+      - name: Run OpenCode with AIWG
+        uses: sst/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: anthropic/claude-sonnet-4-20250514
+          prompt: |
+            You have access to AIWG SDLC framework.
+            Use the aiwg CLI for project management tasks.
+            SDLC artifacts are in .aiwg/ directory.
+            Follow the project's AGENTS.md guidelines.
+```
+
+### 7. Comprehensive Configuration Template
+
+```jsonc
+// opencode.json.aiwg-template
+{
+  "$schema": "https://opencode.ai/config.json",
+
+  // Load SDLC context files
+  "instructions": [
+    "AGENTS.md",
+    ".aiwg/requirements/**/*.md",
+    ".aiwg/architecture/*.md"
+  ],
+
+  // AIWG MCP server
+  "mcp": {
+    "aiwg": {
+      "type": "local",
+      "command": ["aiwg", "mcp", "serve"],
+      "enabled": true
+    }
+  },
+
+  // Global tool configuration
+  "tools": {
+    "todowrite": true,
+    "todoread": true,
+    "webfetch": true
+  },
+
+  // Default permissions (can be overridden per-agent)
+  "permission": {
+    "edit": "allow",
+    "bash": {
+      "aiwg *": "allow",
+      "git status": "allow",
+      "git diff": "allow",
+      "git log*": "allow",
+      "npm test": "allow",
+      "npm run build": "allow",
+      "git push": "ask",
+      "rm -rf": "deny",
+      "*": "ask"
+    },
+    "webfetch": "allow",
+    "doom_loop": "ask",
+    "external_directory": "ask"
+  },
+
+  // Primary SDLC orchestrator agent
+  "agent": {
+    "sdlc": {
+      "description": "SDLC orchestrator - coordinates multi-agent workflows",
+      "mode": "primary",
+      "model": "anthropic/claude-sonnet-4-20250514",
+      "temperature": 0.3,
+      "prompt": "{file:.opencode/prompts/sdlc-orchestrator.txt}"
+    }
+  },
+
+  // Optional: AIWG-branded theme
+  "theme": "aiwg"
+}
+```
+
+### 8. AGENTS.md Template
+
+```markdown
+# AIWG SDLC Framework
+
+This project uses AIWG for structured SDLC workflow management.
+
+## Available Agents
+
+Use `@agent-name` to invoke specialized agents:
+
+| Agent | Purpose |
+|-------|---------|
+| @security-architect | Security analysis and threat modeling |
+| @test-engineer | Test strategy and generation |
+| @requirements-analyst | Requirements refinement |
+| @code-reviewer | Code quality analysis |
+| @deployment-manager | Release planning |
+
+## Available Commands
+
+Type `/command` in the TUI:
+
+| Command | Description |
+|---------|-------------|
+| /security-audit | Run comprehensive security review |
+| /generate-tests | Generate test suite |
+| /flow-gate-check | Check phase gate readiness |
+| /project-status | Get current project status |
+
+## AIWG Tools
+
+Custom tools available via MCP:
+
+- `aiwg_status` - Project status
+- `aiwg_artifact` - Read SDLC artifacts
+- `aiwg_template` - Render templates
+- `aiwg_gate` - Check phase gates
+
+## Artifacts Location
+
+SDLC artifacts are in `.aiwg/`:
+
+```
+.aiwg/
+├── intake/        # Project intake forms
+├── requirements/  # User stories, use cases
+├── architecture/  # SAD, ADRs
+├── planning/      # Phase plans
+├── risks/         # Risk register
+├── testing/       # Test strategy
+├── security/      # Threat models
+└── deployment/    # Deployment plans
+```
+
+## GitHub Integration
+
+Use `/opencode` or `/oc` in issues/PRs to invoke OpenCode with AIWG context.
+```
+
+### 9. Theme Template (Optional)
+
+```json
+// .opencode/themes/aiwg.json
+{
+  "$schema": "https://opencode.ai/theme.json",
+  "defs": {
+    "aiwg-blue": "#2563EB",
+    "aiwg-green": "#10B981",
+    "aiwg-orange": "#F59E0B",
+    "aiwg-red": "#EF4444",
+    "aiwg-purple": "#8B5CF6"
+  },
+  "theme": {
+    "primary": { "dark": "aiwg-blue", "light": "aiwg-blue" },
+    "success": { "dark": "aiwg-green", "light": "aiwg-green" },
+    "warning": { "dark": "aiwg-orange", "light": "aiwg-orange" },
+    "error": { "dark": "aiwg-red", "light": "aiwg-red" },
+    "accent": { "dark": "aiwg-purple", "light": "aiwg-purple" }
+  }
+}
+```
+
+## Implementation Tasks
+
+### Phase 1: Core Integration ✅ COMPLETE
+
+- [x] Update `tools/agents/deploy-agents.mjs`
+  - Added `opencode` provider support
+  - Transform agent metadata to OpenCode format
+  - Map models, tools, permissions per agent type
+  - Generate mode (primary vs subagent) based on agent category
+
+- [x] Create agent transformation function
+  - Parse AIWG agent markdown
+  - Generate OpenCode-compatible frontmatter
+  - Add temperature, maxSteps based on agent type
+  - Configure tools/permissions per agent category
+
+- [x] Update `src/mcp/cli.mjs`
+  - Add `opencode` provider
+  - Merge MCP config into opencode.json format
+
+### Phase 2: Commands and Tools ✅ COMPLETE
+
+- [x] Create command deployment
+  - Convert .claude/commands/*.md to .opencode/command/*.md
+  - Add agent routing (security commands → security-architect)
+  - Add subtask: true for isolation
+  - Include shell injection for context (git status, etc.)
+
+- [x] Create custom tool templates
+  - `.opencode/tool/aiwg-workflow.ts`
+  - Status, artifact, template, gate tools
+
+- [x] Create plugin template
+  - `.opencode/plugin/aiwg-hooks.ts`
+  - Event hooks for automation
+
+### Phase 3: Templates and Documentation ✅ COMPLETE
+
+- [x] Create OpenCode templates directory
+  - `agentic/code/frameworks/sdlc-complete/templates/opencode/`
+  - opencode.json.aiwg-template
+  - AGENTS.md.aiwg-template
+  - tool/aiwg-workflow.ts.aiwg-template
+  - plugin/aiwg-hooks.ts.aiwg-template
+  - themes/aiwg.json.aiwg-template
+  - instructions.md.aiwg-template
+
+- [x] Create GitHub Actions templates
+  - `templates/opencode/ci-cd/opencode-aiwg.yml`
+
+- [x] Create quickstart guide
+  - `docs/integrations/opencode-quickstart.md`
+
+### Phase 4: Testing ✅ COMPLETE
+
+- [x] Create integration tests
+  - `test/integration/opencode-deployment.test.ts`
+  - Agent deployment validation
+  - Command deployment validation
+  - MCP configuration validation
+  - AGENTS.md generation validation
+
+## CLI Commands
+
+```bash
+# Full OpenCode setup
+aiwg -deploy-agents --provider opencode --deploy-commands --create-agents-md
+
+# Deploy only agents
+aiwg -deploy-agents --provider opencode
+
+# Deploy only commands
+aiwg -deploy-commands --provider opencode
+
+# Install MCP server
+aiwg mcp install opencode
+
+# Use SDLC framework with OpenCode
+aiwg use sdlc --provider opencode
+```
+
+## Success Criteria
+
+1. **Agents work** - All SDLC agents deployable and invokable via @mention
+2. **Commands work** - Slash commands executable in TUI
+3. **Tools work** - Custom AIWG tools available
+4. **Plugin works** - Event hooks functional
+5. **MCP works** - AIWG MCP server connected
+6. **GitHub works** - /opencode triggers AIWG-aware sessions
+7. **Config complete** - Permissions, instructions, theme configured
+8. **Tests pass** - Integration tests validate all functionality
+
+## References
+
+- OpenCode Docs: https://opencode.ai/docs
+- OpenCode Agents: https://opencode.ai/docs/agents
+- OpenCode Commands: https://opencode.ai/docs/commands
+- OpenCode Config: https://opencode.ai/docs/config
+- OpenCode MCP: https://opencode.ai/docs/mcp-servers
+- OpenCode Custom Tools: https://opencode.ai/docs/custom-tools
+- OpenCode Plugins: https://opencode.ai/docs/plugins
+- OpenCode GitHub: https://opencode.ai/docs/github
+- OpenCode Themes: https://opencode.ai/docs/themes
+- OpenCode Permissions: https://opencode.ai/docs/permissions
+- GitHub: https://github.com/sst/opencode

--- a/.claude/rules/agent-deployment.md
+++ b/.claude/rules/agent-deployment.md
@@ -3,6 +3,7 @@ paths:
   - ".claude/agents/**"
   - ".factory/droids/**"
   - ".codex/agents/**"
+  - ".opencode/agent/**"
   - "agentic/**"
   - "AGENTS.md"
 ---
@@ -39,6 +40,12 @@ aiwg -deploy-agents --mode sdlc
 # Factory AI (creates .factory/droids/ + AGENTS.md)
 aiwg -deploy-agents --provider factory --mode sdlc --deploy-commands --create-agents-md
 
+# OpenCode (creates .opencode/agent/ + AGENTS.md)
+aiwg -deploy-agents --provider opencode --mode sdlc --deploy-commands --create-agents-md
+
+# Cursor (creates .cursor/rules/ + AGENTS.md)
+aiwg -deploy-agents --provider cursor --mode sdlc --deploy-commands --create-agents-md
+
 # OpenAI/Codex (creates .codex/agents/)
 aiwg -deploy-agents --provider openai
 
@@ -60,6 +67,8 @@ aiwg -deploy-agents --provider factory \
 ### Provider-Specific Guidance
 
 - **Factory AI**: See `agentic/code/frameworks/sdlc-complete/agents/factory-compat.md`
+- **OpenCode**: See `docs/integrations/opencode-quickstart.md`
+- **Cursor**: See `docs/integrations/cursor-quickstart.md`
 - **OpenAI/Codex**: See `agentic/code/frameworks/sdlc-complete/agents/openai-compat.md`
 
 ## Agent Definition Format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Use `@path/to/file.md` in your message to load specific documentation:
 | Claude Code | `.claude/agents/` | `aiwg -deploy-agents` |
 | Warp Terminal | `WARP.md` | Symlinked to CLAUDE.md |
 | Factory AI | `.factory/droids/` | `aiwg -deploy-agents --provider factory` |
+| OpenCode | `.opencode/agent/` | `aiwg -deploy-agents --provider opencode` |
 | Cursor | `.cursor/rules/` | `aiwg -deploy-agents --provider cursor` |
 | OpenAI/Codex | `~/.codex/skills/` | `aiwg -deploy-agents --provider codex` |
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ aiwg use sdlc --provider warp
 # Factory AI (creates .factory/droids/ + AGENTS.md)
 aiwg use sdlc --provider factory
 
+# OpenCode (creates .opencode/agent/ + AGENTS.md)
+aiwg use sdlc --provider opencode
+
+# Cursor (creates .cursor/rules/ + AGENTS.md)
+aiwg use sdlc --provider cursor
+
 # OpenAI/Codex (experimental)
 aiwg use sdlc --provider openai
 ```

--- a/agentic/code/frameworks/sdlc-complete/templates/opencode/AGENTS.md.aiwg-template
+++ b/agentic/code/frameworks/sdlc-complete/templates/opencode/AGENTS.md.aiwg-template
@@ -1,0 +1,73 @@
+# AGENTS.md - OpenCode Integration
+
+This file provides project-specific guidance for OpenCode's AI coding agent.
+
+<!-- AIWG SDLC Framework Integration -->
+
+## AIWG SDLC Framework
+
+This project uses the AI Writing Guide (AIWG) SDLC Framework for software development lifecycle management.
+
+### Available Agents
+
+AIWG agents are deployed to `.opencode/agent/` and can be invoked via `@agent-name`:
+
+**Planning & Architecture**:
+- `@architecture-designer` - System architecture and design decisions
+- `@requirements-analyst` - Requirements gathering and analysis
+- `@api-designer` - API design and contract definitions
+
+**Implementation**:
+- `@software-implementer` - Production code implementation
+- `@test-engineer` - Test development and coverage
+- `@code-reviewer` - Code review and quality
+
+**Security & Quality**:
+- `@security-architect` - Security architecture and threat modeling
+- `@security-auditor` - Security review and vulnerability assessment
+- `@performance-engineer` - Performance optimization
+
+**Documentation**:
+- `@technical-writer` - Technical documentation
+- `@architecture-documenter` - Architecture documentation
+- `@documentation-synthesizer` - Multi-source documentation consolidation
+
+### Available Commands
+
+AIWG commands are deployed to `.opencode/command/` and can be invoked via `/command`:
+
+- `/project-status` - Current project status and next steps
+- `/flow-gate-check <phase>` - Validate phase gate criteria
+- `/security-gate` - Run security validation
+- `/generate-tests` - Generate test suite
+
+### SDLC Artifacts Location
+
+All SDLC artifacts are stored in `.aiwg/`:
+
+```
+.aiwg/
+├── intake/        # Project intake forms
+├── requirements/  # User stories, use cases
+├── architecture/  # SAD, ADRs
+├── planning/      # Phase plans
+├── risks/         # Risk register
+├── testing/       # Test strategy
+├── security/      # Threat models
+├── deployment/    # Deployment plans
+├── working/       # Temporary (safe to delete)
+└── reports/       # Generated reports
+```
+
+### Workflow Patterns
+
+**Multi-agent review**: For comprehensive artifact review, invoke multiple agents in parallel using the `aiwg-orchestrator` tool.
+
+**Phase transitions**: Use `/flow-inception-to-elaboration`, `/flow-elaboration-to-construction`, etc. for guided phase transitions.
+
+**Continuous validation**: Use `/flow-security-review-cycle`, `/flow-test-strategy-execution` for ongoing quality assurance.
+
+## Project-Specific Configuration
+
+<!-- Add project-specific instructions below this line -->
+

--- a/agentic/code/frameworks/sdlc-complete/templates/opencode/ci-cd/opencode-aiwg.yml
+++ b/agentic/code/frameworks/sdlc-complete/templates/opencode/ci-cd/opencode-aiwg.yml
@@ -1,0 +1,73 @@
+# OpenCode GitHub Integration for AIWG SDLC Framework
+#
+# This workflow enables AI-assisted issue triage, PR reviews, and implementation
+# via OpenCode integrated with AIWG SDLC agents and workflows.
+#
+# To install: Copy to .github/workflows/opencode-aiwg.yml
+# Configure: Set ANTHROPIC_API_KEY in repository secrets
+#
+# Usage in issues/PRs:
+#   /opencode explain this issue
+#   /opencode fix this
+#   /oc review this PR
+#   /oc implement the feature described
+
+name: OpenCode AIWG Integration
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install AIWG CLI
+        run: npm install -g ai-writing-guide
+
+      - name: Deploy AIWG Agents to OpenCode
+        run: |
+          aiwg -deploy-agents --provider opencode --mode sdlc --deploy-commands
+
+      - name: Run OpenCode
+        uses: sst/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: anthropic/claude-sonnet-4-20250514
+          share: true
+          prompt: |
+            You have access to AIWG SDLC Framework agents deployed in .opencode/agent/.
+            Use @agent-name syntax to invoke specialized agents for:
+            - @security-architect for security review
+            - @test-engineer for test generation
+            - @code-reviewer for code review
+            - @technical-writer for documentation
+
+            AIWG commands are available in .opencode/command/:
+            - /project-status for current project state
+            - /flow-gate-check for phase validation
+            - /security-gate for security validation
+
+            SDLC artifacts should be stored in .aiwg/ directory.
+            Follow AIWG workflow patterns for comprehensive analysis.

--- a/agentic/code/frameworks/sdlc-complete/templates/opencode/instructions.md.aiwg-template
+++ b/agentic/code/frameworks/sdlc-complete/templates/opencode/instructions.md.aiwg-template
@@ -1,0 +1,83 @@
+# AIWG SDLC Framework Instructions
+
+This file provides project-specific instructions for AI agents using the AIWG SDLC Framework.
+
+## Framework Overview
+
+The AI Writing Guide (AIWG) SDLC Framework provides structured software development lifecycle management through specialized agents and workflows.
+
+## Using AIWG Agents
+
+### Invoking Agents
+
+Use `@agent-name` to invoke specialized SDLC agents:
+
+```
+@security-architect Review the authentication implementation for vulnerabilities
+@test-engineer Generate unit tests for the user service
+@code-reviewer Review this PR for code quality and best practices
+```
+
+### Available Agent Categories
+
+**Planning & Design**:
+- `@requirements-analyst` - Requirements gathering and analysis
+- `@architecture-designer` - System architecture decisions
+- `@api-designer` - API contract definitions
+
+**Implementation**:
+- `@software-implementer` - Production code implementation
+- `@test-engineer` - Test development
+- `@code-reviewer` - Code review
+
+**Quality & Security**:
+- `@security-architect` - Security architecture
+- `@security-auditor` - Vulnerability assessment
+- `@performance-engineer` - Performance optimization
+
+**Documentation**:
+- `@technical-writer` - Technical documentation
+- `@documentation-synthesizer` - Multi-source consolidation
+
+## Using AIWG Commands
+
+Commands are invoked via `/command-name`:
+
+```
+/project-status
+/flow-gate-check elaboration
+/security-gate
+/generate-tests
+```
+
+## SDLC Phases
+
+1. **Inception** - Problem validation, vision, risks
+2. **Elaboration** - Requirements, architecture baseline
+3. **Construction** - Implementation, testing
+4. **Transition** - Deployment, UAT, handover
+
+## Artifact Management
+
+All SDLC artifacts are stored in `.aiwg/`:
+
+- `intake/` - Project intake forms
+- `requirements/` - User stories, use cases
+- `architecture/` - SAD, ADRs
+- `planning/` - Phase plans
+- `testing/` - Test strategy, plans
+- `security/` - Threat models
+- `deployment/` - Deployment plans
+
+## Best Practices
+
+1. **Use appropriate agents** - Match agent expertise to task
+2. **Follow workflows** - Use `/flow-*` commands for structured transitions
+3. **Maintain traceability** - Link requirements to code to tests
+4. **Document decisions** - Create ADRs for significant choices
+5. **Validate quality** - Run security and test gates regularly
+
+## Project-Specific Notes
+
+<!-- Add project-specific instructions below this line -->
+

--- a/agentic/code/frameworks/sdlc-complete/templates/opencode/opencode.json.aiwg-template
+++ b/agentic/code/frameworks/sdlc-complete/templates/opencode/opencode.json.aiwg-template
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-sonnet-4-20250514",
+  "provider": {
+    "anthropic": {
+      "disabled": false
+    }
+  },
+  "mcp": {
+    "aiwg": {
+      "type": "local",
+      "command": ["npx", "aiwg", "mcp", "serve"]
+    }
+  },
+  "instructions": [
+    "AGENTS.md",
+    ".aiwg/instructions.md"
+  ],
+  "formatter": {
+    "prettier": {
+      "extensions": [".js", ".ts", ".jsx", ".tsx", ".json", ".md"]
+    }
+  }
+}

--- a/agentic/code/frameworks/sdlc-complete/templates/opencode/plugin/aiwg-hooks.ts.aiwg-template
+++ b/agentic/code/frameworks/sdlc-complete/templates/opencode/plugin/aiwg-hooks.ts.aiwg-template
@@ -1,0 +1,121 @@
+/**
+ * AIWG Event Hooks Plugin for OpenCode
+ *
+ * Integrates AIWG SDLC workflows with OpenCode's event system.
+ * Provides automated quality checks, artifact updates, and workflow triggers.
+ *
+ * @implements OpenCode Plugin API
+ * @see https://opencode.ai/docs/plugins
+ */
+
+import { plugin, defineHook } from "@opencode-ai/plugin";
+
+export default plugin({
+  name: "aiwg-hooks",
+  version: "1.0.0",
+  description: "AIWG SDLC integration hooks for automated quality and workflow management",
+
+  hooks: {
+    /**
+     * After session completes, update project status
+     */
+    "session.idle": defineHook({
+      execute: async (context) => {
+        // Log session completion for traceability
+        console.log(`[AIWG] Session idle - changes may require artifact updates`);
+
+        // Check if significant changes were made that might require SDLC updates
+        const { session } = context;
+        if (session.toolCalls > 10 || session.filesModified > 5) {
+          console.log(`[AIWG] Significant session activity detected:`);
+          console.log(`  - Tool calls: ${session.toolCalls}`);
+          console.log(`  - Files modified: ${session.filesModified}`);
+          console.log(`  - Consider running /project-status to update SDLC artifacts`);
+        }
+      }
+    }),
+
+    /**
+     * Before executing dangerous bash commands, check permissions
+     */
+    "tool.execute.before": defineHook({
+      filter: (event) => event.tool === "bash",
+      execute: async (context) => {
+        const { args } = context;
+        const command = args.command as string;
+
+        // Warn about potentially destructive commands
+        const destructivePatterns = [
+          /rm\s+-rf\s+\//,
+          /git\s+push\s+--force/,
+          /git\s+reset\s+--hard/,
+          /drop\s+database/i,
+          /truncate\s+table/i
+        ];
+
+        for (const pattern of destructivePatterns) {
+          if (pattern.test(command)) {
+            console.warn(`[AIWG Security] Potentially destructive command detected: ${command}`);
+            console.warn(`[AIWG Security] This command should be reviewed before execution.`);
+          }
+        }
+
+        // Track deployment-related commands for SDLC
+        if (command.includes("deploy") || command.includes("release")) {
+          console.log(`[AIWG] Deployment activity detected - consider updating deployment artifacts`);
+        }
+      }
+    }),
+
+    /**
+     * After file edits, check for SDLC-relevant changes
+     */
+    "file.edited": defineHook({
+      execute: async (context) => {
+        const { path } = context;
+
+        // Track changes to key areas for SDLC documentation
+        const sdlcRelevantPaths = [
+          { pattern: /src\/.*\.(ts|js|py|go|rs)$/, category: "implementation" },
+          { pattern: /test\/.*\.(test|spec)\.(ts|js|py)$/, category: "testing" },
+          { pattern: /\.github\/workflows\//, category: "deployment" },
+          { pattern: /Dockerfile|docker-compose/, category: "deployment" },
+          { pattern: /package\.json|requirements\.txt|go\.mod/, category: "dependencies" },
+          { pattern: /\.aiwg\//, category: "sdlc-artifacts" }
+        ];
+
+        for (const { pattern, category } of sdlcRelevantPaths) {
+          if (pattern.test(path)) {
+            console.log(`[AIWG] ${category} file modified: ${path}`);
+          }
+        }
+
+        // Special handling for architecture-relevant changes
+        if (path.includes("/api/") || path.includes("/schema/") || path.includes("/models/")) {
+          console.log(`[AIWG] Architecture-relevant file modified - consider ADR if significant`);
+        }
+      }
+    }),
+
+    /**
+     * Session finished - provide AIWG summary
+     */
+    "session.finished": defineHook({
+      execute: async (context) => {
+        const { session } = context;
+
+        console.log(`\n[AIWG Session Summary]`);
+        console.log(`  Duration: ${session.duration}ms`);
+        console.log(`  Tool calls: ${session.toolCalls}`);
+        console.log(`  Files modified: ${session.filesModified}`);
+
+        if (session.filesModified > 0) {
+          console.log(`\n[AIWG Recommendations]`);
+          console.log(`  - Run /project-status to review current state`);
+          console.log(`  - Consider updating relevant SDLC artifacts in .aiwg/`);
+          console.log(`  - Commit changes with descriptive message`);
+        }
+      }
+    })
+  }
+});

--- a/agentic/code/frameworks/sdlc-complete/templates/opencode/themes/aiwg.json.aiwg-template
+++ b/agentic/code/frameworks/sdlc-complete/templates/opencode/themes/aiwg.json.aiwg-template
@@ -1,0 +1,221 @@
+{
+  "$schema": "https://opencode.ai/theme.json",
+  "defs": {
+    "aiwg-bg": "#1a1b26",
+    "aiwg-bg-panel": "#24283b",
+    "aiwg-bg-element": "#292e42",
+    "aiwg-fg": "#c0caf5",
+    "aiwg-fg-muted": "#565f89",
+    "aiwg-primary": "#7aa2f7",
+    "aiwg-secondary": "#bb9af7",
+    "aiwg-accent": "#7dcfff",
+    "aiwg-success": "#9ece6a",
+    "aiwg-warning": "#e0af68",
+    "aiwg-error": "#f7768e",
+    "aiwg-info": "#2ac3de",
+    "aiwg-border": "#3b4261",
+    "aiwg-border-active": "#7aa2f7"
+  },
+  "theme": {
+    "primary": {
+      "dark": "aiwg-primary",
+      "light": "#2563eb"
+    },
+    "secondary": {
+      "dark": "aiwg-secondary",
+      "light": "#7c3aed"
+    },
+    "accent": {
+      "dark": "aiwg-accent",
+      "light": "#0891b2"
+    },
+    "error": {
+      "dark": "aiwg-error",
+      "light": "#dc2626"
+    },
+    "warning": {
+      "dark": "aiwg-warning",
+      "light": "#d97706"
+    },
+    "success": {
+      "dark": "aiwg-success",
+      "light": "#16a34a"
+    },
+    "info": {
+      "dark": "aiwg-info",
+      "light": "#0284c7"
+    },
+    "text": {
+      "dark": "aiwg-fg",
+      "light": "#1e293b"
+    },
+    "textMuted": {
+      "dark": "aiwg-fg-muted",
+      "light": "#64748b"
+    },
+    "background": {
+      "dark": "aiwg-bg",
+      "light": "#ffffff"
+    },
+    "backgroundPanel": {
+      "dark": "aiwg-bg-panel",
+      "light": "#f8fafc"
+    },
+    "backgroundElement": {
+      "dark": "aiwg-bg-element",
+      "light": "#f1f5f9"
+    },
+    "border": {
+      "dark": "aiwg-border",
+      "light": "#e2e8f0"
+    },
+    "borderActive": {
+      "dark": "aiwg-border-active",
+      "light": "#2563eb"
+    },
+    "borderSubtle": {
+      "dark": "#2a2f42",
+      "light": "#f1f5f9"
+    },
+    "diffAdded": {
+      "dark": "aiwg-success",
+      "light": "#16a34a"
+    },
+    "diffRemoved": {
+      "dark": "aiwg-error",
+      "light": "#dc2626"
+    },
+    "diffContext": {
+      "dark": "aiwg-fg-muted",
+      "light": "#64748b"
+    },
+    "diffHunkHeader": {
+      "dark": "aiwg-secondary",
+      "light": "#7c3aed"
+    },
+    "diffHighlightAdded": {
+      "dark": "#3d5a3d",
+      "light": "#bbf7d0"
+    },
+    "diffHighlightRemoved": {
+      "dark": "#5a3d3d",
+      "light": "#fecaca"
+    },
+    "diffAddedBg": {
+      "dark": "#1a2f1a",
+      "light": "#dcfce7"
+    },
+    "diffRemovedBg": {
+      "dark": "#2f1a1a",
+      "light": "#fee2e2"
+    },
+    "diffContextBg": {
+      "dark": "aiwg-bg-panel",
+      "light": "#f8fafc"
+    },
+    "diffLineNumber": {
+      "dark": "aiwg-fg-muted",
+      "light": "#94a3b8"
+    },
+    "diffAddedLineNumberBg": {
+      "dark": "#1a2f1a",
+      "light": "#dcfce7"
+    },
+    "diffRemovedLineNumberBg": {
+      "dark": "#2f1a1a",
+      "light": "#fee2e2"
+    },
+    "markdownText": {
+      "dark": "aiwg-fg",
+      "light": "#1e293b"
+    },
+    "markdownHeading": {
+      "dark": "aiwg-primary",
+      "light": "#2563eb"
+    },
+    "markdownLink": {
+      "dark": "aiwg-accent",
+      "light": "#0891b2"
+    },
+    "markdownLinkText": {
+      "dark": "aiwg-primary",
+      "light": "#2563eb"
+    },
+    "markdownCode": {
+      "dark": "aiwg-success",
+      "light": "#16a34a"
+    },
+    "markdownBlockQuote": {
+      "dark": "aiwg-fg-muted",
+      "light": "#64748b"
+    },
+    "markdownEmph": {
+      "dark": "aiwg-warning",
+      "light": "#d97706"
+    },
+    "markdownStrong": {
+      "dark": "aiwg-error",
+      "light": "#dc2626"
+    },
+    "markdownHorizontalRule": {
+      "dark": "aiwg-border",
+      "light": "#e2e8f0"
+    },
+    "markdownListItem": {
+      "dark": "aiwg-primary",
+      "light": "#2563eb"
+    },
+    "markdownListEnumeration": {
+      "dark": "aiwg-secondary",
+      "light": "#7c3aed"
+    },
+    "markdownImage": {
+      "dark": "aiwg-accent",
+      "light": "#0891b2"
+    },
+    "markdownImageText": {
+      "dark": "aiwg-primary",
+      "light": "#2563eb"
+    },
+    "markdownCodeBlock": {
+      "dark": "aiwg-fg",
+      "light": "#1e293b"
+    },
+    "syntaxComment": {
+      "dark": "aiwg-fg-muted",
+      "light": "#64748b"
+    },
+    "syntaxKeyword": {
+      "dark": "aiwg-secondary",
+      "light": "#7c3aed"
+    },
+    "syntaxFunction": {
+      "dark": "aiwg-primary",
+      "light": "#2563eb"
+    },
+    "syntaxVariable": {
+      "dark": "aiwg-accent",
+      "light": "#0891b2"
+    },
+    "syntaxString": {
+      "dark": "aiwg-success",
+      "light": "#16a34a"
+    },
+    "syntaxNumber": {
+      "dark": "aiwg-warning",
+      "light": "#d97706"
+    },
+    "syntaxType": {
+      "dark": "aiwg-info",
+      "light": "#0284c7"
+    },
+    "syntaxOperator": {
+      "dark": "aiwg-secondary",
+      "light": "#7c3aed"
+    },
+    "syntaxPunctuation": {
+      "dark": "aiwg-fg",
+      "light": "#1e293b"
+    }
+  }
+}

--- a/agentic/code/frameworks/sdlc-complete/templates/opencode/tool/aiwg-workflow.ts.aiwg-template
+++ b/agentic/code/frameworks/sdlc-complete/templates/opencode/tool/aiwg-workflow.ts.aiwg-template
@@ -1,0 +1,176 @@
+/**
+ * AIWG Workflow Tool for OpenCode
+ *
+ * Provides AIWG SDLC workflow capabilities as a custom OpenCode tool.
+ *
+ * @implements Custom OpenCode Tool API
+ * @see https://opencode.ai/docs/custom-tools
+ */
+
+import { tool } from "@opencode-ai/plugin";
+import { z } from "zod";
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Execute AIWG workflow command
+ */
+export const runWorkflow = tool({
+  name: "aiwg-workflow",
+  description: "Execute an AIWG SDLC workflow command. Available workflows: project-status, gate-check, security-review, test-execution, deployment.",
+  parameters: z.object({
+    workflow: z.enum([
+      "project-status",
+      "gate-check",
+      "security-review",
+      "test-execution",
+      "deployment",
+      "risk-management",
+      "requirements-evolution"
+    ]).describe("The workflow to execute"),
+    phase: z.string().optional().describe("Phase name for gate-check workflow"),
+    iteration: z.number().optional().describe("Iteration number for iterative workflows"),
+    guidance: z.string().optional().describe("Optional strategic guidance for the workflow")
+  }),
+  execute: async ({ workflow, phase, iteration, guidance }) => {
+    const args = [];
+
+    switch (workflow) {
+      case "project-status":
+        args.push("project-status");
+        break;
+      case "gate-check":
+        args.push("gate-check", phase || "inception");
+        break;
+      case "security-review":
+        args.push("security-review");
+        if (iteration) args.push("--iteration", String(iteration));
+        break;
+      case "test-execution":
+        args.push("test-execution");
+        if (iteration) args.push("--iteration", String(iteration));
+        break;
+      case "deployment":
+        args.push("deploy-to-production");
+        break;
+      case "risk-management":
+        args.push("risk-management");
+        if (iteration) args.push("--iteration", String(iteration));
+        break;
+      case "requirements-evolution":
+        args.push("requirements-evolution");
+        if (iteration) args.push("--iteration", String(iteration));
+        break;
+    }
+
+    if (guidance) {
+      args.push("--guidance", guidance);
+    }
+
+    try {
+      const result = execSync(`npx aiwg ${args.join(" ")}`, {
+        encoding: "utf-8",
+        timeout: 300000 // 5 minutes
+      });
+      return { success: true, output: result };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error"
+      };
+    }
+  }
+});
+
+/**
+ * Read AIWG artifact
+ */
+export const readArtifact = tool({
+  name: "aiwg-artifact-read",
+  description: "Read an AIWG SDLC artifact from the .aiwg directory",
+  parameters: z.object({
+    category: z.enum([
+      "intake",
+      "requirements",
+      "architecture",
+      "planning",
+      "risks",
+      "testing",
+      "security",
+      "deployment",
+      "reports"
+    ]).describe("The artifact category"),
+    filename: z.string().describe("The artifact filename")
+  }),
+  execute: async ({ category, filename }) => {
+    const artifactPath = path.join(process.cwd(), ".aiwg", category, filename);
+
+    if (!fs.existsSync(artifactPath)) {
+      return {
+        success: false,
+        error: `Artifact not found: ${artifactPath}`
+      };
+    }
+
+    try {
+      const content = fs.readFileSync(artifactPath, "utf-8");
+      return { success: true, content };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error"
+      };
+    }
+  }
+});
+
+/**
+ * List AIWG artifacts
+ */
+export const listArtifacts = tool({
+  name: "aiwg-artifact-list",
+  description: "List all AIWG SDLC artifacts in a category",
+  parameters: z.object({
+    category: z.enum([
+      "intake",
+      "requirements",
+      "architecture",
+      "planning",
+      "risks",
+      "testing",
+      "security",
+      "deployment",
+      "reports"
+    ]).optional().describe("The artifact category (omit for all categories)")
+  }),
+  execute: async ({ category }) => {
+    const aiwgDir = path.join(process.cwd(), ".aiwg");
+
+    if (!fs.existsSync(aiwgDir)) {
+      return {
+        success: false,
+        error: "No .aiwg directory found. Initialize AIWG first."
+      };
+    }
+
+    const result: Record<string, string[]> = {};
+
+    const categories = category
+      ? [category]
+      : ["intake", "requirements", "architecture", "planning", "risks", "testing", "security", "deployment", "reports"];
+
+    for (const cat of categories) {
+      const catDir = path.join(aiwgDir, cat);
+      if (fs.existsSync(catDir)) {
+        const files = fs.readdirSync(catDir)
+          .filter(f => f.endsWith(".md") || f.endsWith(".json"));
+        if (files.length > 0) {
+          result[cat] = files;
+        }
+      }
+    }
+
+    return { success: true, artifacts: result };
+  }
+});

--- a/docs/integrations/cross-platform-config.md
+++ b/docs/integrations/cross-platform-config.md
@@ -27,6 +27,9 @@ While the configuration file is shared, each platform has its own deployment str
 | **Claude Code** | `CLAUDE.md` | `.claude/agents/`, `.claude/commands/` | `aiwg -deploy-agents` |
 | **Warp Terminal** | `WARP.md` (→ CLAUDE.md) | Inline in WARP.md | `aiwg -deploy-agents --platform warp` |
 | **Factory AI** | `AGENTS.md` | `.factory/droids/`, `.factory/commands/` | `aiwg -deploy-agents --provider factory` |
+| **OpenCode** | `AGENTS.md` | `.opencode/agent/`, `.opencode/command/` | `aiwg -deploy-agents --provider opencode` |
+| **Codex/OpenAI** | `AGENTS.md` | `.codex/agents/`, `.codex/prompts/` | `aiwg -deploy-agents --provider openai` |
+| **Cursor** | Context Rules | `.cursor/rules/`, `.cursor/agents/` | `aiwg -deploy-agents --provider cursor` |
 
 ## How It Works
 
@@ -157,6 +160,9 @@ So Factory gets its own `AGENTS.md` template instead of reusing CLAUDE.md.
 - **Claude Code Setup**: [docs/integrations/claude-code-quickstart.md](claude-code-quickstart.md)
 - **Warp Terminal Setup**: [docs/integrations/warp-terminal-quickstart.md](warp-terminal-quickstart.md)
 - **Factory AI Setup**: [docs/integrations/factory-quickstart.md](factory-quickstart.md)
+- **OpenCode Setup**: [docs/integrations/opencode-quickstart.md](opencode-quickstart.md)
+- **Codex/OpenAI Setup**: [docs/integrations/codex-quickstart.md](codex-quickstart.md)
+- **Cursor Setup**: [docs/integrations/cursor-quickstart.md](cursor-quickstart.md)
 - **CLAUDE.md Contents**: [/CLAUDE.md](../../CLAUDE.md)
 
 ## Summary

--- a/docs/integrations/opencode-quickstart.md
+++ b/docs/integrations/opencode-quickstart.md
@@ -1,0 +1,303 @@
+# OpenCode Integration Guide
+
+This guide explains how to integrate AIWG with [OpenCode](https://github.com/sst/opencode), the open-source AI coding agent.
+
+## Overview
+
+OpenCode provides a TUI-based AI coding assistant with support for:
+- **Agents**: Specialized AI personas with custom tools and permissions
+- **Commands**: Slash commands with shell injection and file references
+- **Custom Tools**: TypeScript-based tool extensions
+- **Plugins**: Event hooks for workflow automation
+- **MCP Servers**: Model Context Protocol integration
+- **GitHub Integration**: `/opencode` triggers in issues and PRs
+
+AIWG integrates with all of these features for comprehensive SDLC support.
+
+## Quick Start
+
+### 1. Install OpenCode
+
+```bash
+# macOS/Linux
+curl -fsSL https://opencode.ai/install | sh
+
+# Or via npm
+npm install -g opencode
+```
+
+### 2. Deploy AIWG Agents
+
+```bash
+# Deploy agents, commands, and create AGENTS.md
+aiwg -deploy-agents --provider opencode --mode sdlc --deploy-commands --create-agents-md
+```
+
+This creates:
+- `.opencode/agent/` - AIWG SDLC agents
+- `.opencode/command/` - AIWG slash commands
+- `AGENTS.md` - Project-specific instructions
+
+### 3. Configure MCP Server (Optional)
+
+```bash
+# Add AIWG MCP server to opencode.json
+aiwg mcp install opencode
+```
+
+## Directory Structure
+
+After deployment:
+
+```
+project/
+├── .opencode/
+│   ├── agent/               # AIWG SDLC agents
+│   │   ├── security-architect.md
+│   │   ├── test-engineer.md
+│   │   ├── code-reviewer.md
+│   │   └── ...
+│   ├── command/             # AIWG commands
+│   │   ├── project-status.md
+│   │   ├── flow-gate-check.md
+│   │   └── ...
+│   ├── tool/                # Custom tools (optional)
+│   │   └── aiwg-workflow.ts
+│   ├── plugin/              # Event hooks (optional)
+│   │   └── aiwg-hooks.ts
+│   └── themes/              # AIWG theme (optional)
+│       └── aiwg.json
+├── opencode.json            # OpenCode configuration
+├── AGENTS.md                # Project instructions
+└── .aiwg/                   # SDLC artifacts
+    ├── requirements/
+    ├── architecture/
+    └── ...
+```
+
+## Using AIWG Agents
+
+### Invoke via @-mention
+
+```
+@security-architect Review the authentication implementation
+@test-engineer Generate unit tests for the user service
+@code-reviewer Review this PR for quality issues
+```
+
+### Available Agent Categories
+
+| Category | Agents |
+|----------|--------|
+| **Planning** | `@requirements-analyst`, `@architecture-designer`, `@api-designer` |
+| **Implementation** | `@software-implementer`, `@test-engineer`, `@code-reviewer` |
+| **Security** | `@security-architect`, `@security-auditor` |
+| **Documentation** | `@technical-writer`, `@documentation-synthesizer` |
+| **Operations** | `@deployment-manager`, `@reliability-engineer` |
+
+## Using AIWG Commands
+
+### Invoke via /command
+
+```
+/project-status
+/flow-gate-check elaboration
+/security-gate
+/generate-tests
+```
+
+### Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/project-status` | Current project state and recommendations |
+| `/flow-gate-check <phase>` | Validate phase gate criteria |
+| `/flow-inception-to-elaboration` | Transition from Inception to Elaboration |
+| `/security-gate` | Run security validation |
+| `/generate-tests` | Generate test suite |
+
+## Configuration
+
+### opencode.json
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-sonnet-4-20250514",
+  "mcp": {
+    "aiwg": {
+      "type": "local",
+      "command": ["aiwg", "mcp", "serve"]
+    }
+  },
+  "instructions": [
+    "AGENTS.md",
+    ".aiwg/instructions.md"
+  ]
+}
+```
+
+### Agent Permissions
+
+AIWG agents are configured with appropriate tool restrictions:
+
+```yaml
+---
+description: Security architecture and threat modeling
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.2
+maxSteps: 30
+tools:
+  write: false
+  edit: false
+  patch: false
+  bash: true
+  webfetch: true
+permission:
+  bash:
+    "git *": allow
+    "npm audit": allow
+    "*": ask
+---
+```
+
+## Custom Tools
+
+Deploy the AIWG workflow tool for enhanced capabilities:
+
+```bash
+# Copy from templates
+cp ~/.local/share/ai-writing-guide/agentic/code/frameworks/sdlc-complete/templates/opencode/tool/aiwg-workflow.ts.aiwg-template .opencode/tool/aiwg-workflow.ts
+
+# Install dependencies
+npm install @opencode-ai/plugin zod
+```
+
+This provides:
+- `aiwg-workflow` - Execute AIWG workflows
+- `aiwg-artifact-read` - Read SDLC artifacts
+- `aiwg-artifact-list` - List artifacts by category
+
+## Plugins (Event Hooks)
+
+Deploy AIWG hooks for automated quality checks:
+
+```bash
+cp ~/.local/share/ai-writing-guide/agentic/code/frameworks/sdlc-complete/templates/opencode/plugin/aiwg-hooks.ts.aiwg-template .opencode/plugin/aiwg-hooks.ts
+```
+
+This provides:
+- Session activity tracking
+- Destructive command warnings
+- SDLC-relevant file change detection
+- Session summaries with recommendations
+
+## GitHub Integration
+
+Enable AI-assisted issue/PR handling:
+
+```yaml
+# .github/workflows/opencode-aiwg.yml
+name: OpenCode AIWG Integration
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install -g ai-writing-guide
+      - run: aiwg -deploy-agents --provider opencode --mode sdlc --deploy-commands
+      - uses: sst/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: anthropic/claude-sonnet-4-20250514
+```
+
+Usage in issues/PRs:
+```
+/opencode explain this issue
+/opencode fix this
+/oc review this PR
+```
+
+## Themes
+
+Apply the AIWG theme:
+
+```bash
+cp ~/.local/share/ai-writing-guide/agentic/code/frameworks/sdlc-complete/templates/opencode/themes/aiwg.json.aiwg-template .opencode/themes/aiwg.json
+```
+
+Then in opencode.json:
+
+```json
+{
+  "theme": "aiwg"
+}
+```
+
+## Model Configuration
+
+Override default models:
+
+```bash
+aiwg -deploy-agents --provider opencode \
+  --reasoning-model anthropic/claude-opus-4-20250514 \
+  --coding-model anthropic/claude-sonnet-4-20250514 \
+  --efficiency-model anthropic/claude-haiku-4-20250514
+```
+
+## Best Practices
+
+1. **Use appropriate agents** - Match agent expertise to the task
+2. **Follow SDLC workflows** - Use `/flow-*` commands for phase transitions
+3. **Maintain artifacts** - Keep `.aiwg/` directory updated
+4. **Enable plugins** - Automated quality checks and tracking
+5. **Use MCP** - Full AIWG capabilities via MCP server
+
+## Troubleshooting
+
+### Agents not appearing
+
+```bash
+# Verify deployment
+ls -la .opencode/agent/
+
+# Redeploy with force
+aiwg -deploy-agents --provider opencode --force
+```
+
+### MCP server not connecting
+
+```bash
+# Test MCP server directly
+aiwg mcp serve
+
+# Check opencode.json configuration
+cat opencode.json | grep -A5 "mcp"
+```
+
+### Permission errors
+
+Review agent permissions in `.opencode/agent/*.md` frontmatter. Adjust `permission:` block as needed.
+
+## References
+
+- [OpenCode Documentation](https://opencode.ai/docs)
+- [OpenCode GitHub](https://github.com/sst/opencode)
+- [AIWG SDLC Framework](../reference/sdlc-framework.md)
+- [AIWG Agent Catalog](../reference/agents.md)

--- a/test/integration/opencode-deployment.test.ts
+++ b/test/integration/opencode-deployment.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Integration tests for OpenCode provider deployment
+ *
+ * Tests AIWG agent and command deployment to OpenCode format.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('OpenCode Deployment', () => {
+  let testDir: string;
+  const deployScript = path.resolve(__dirname, '../../tools/agents/deploy-agents.mjs');
+
+  beforeEach(() => {
+    // Create temporary test directory
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiwg-opencode-test-'));
+  });
+
+  afterEach(() => {
+    // Cleanup test directory
+    if (testDir && fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('Agent Deployment', () => {
+    it('should deploy agents to .opencode/agent/ directory', () => {
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc`, {
+        encoding: 'utf-8'
+      });
+
+      const agentDir = path.join(testDir, '.opencode', 'agent');
+      expect(fs.existsSync(agentDir)).toBe(true);
+
+      const agents = fs.readdirSync(agentDir);
+      expect(agents.length).toBeGreaterThan(0);
+      expect(agents.some(a => a.endsWith('.md'))).toBe(true);
+    });
+
+    it('should transform agent frontmatter to OpenCode format', () => {
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc`, {
+        encoding: 'utf-8'
+      });
+
+      const agentDir = path.join(testDir, '.opencode', 'agent');
+      const agents = fs.readdirSync(agentDir).filter(f => f.endsWith('.md'));
+
+      // Pick first agent to verify format
+      const agentContent = fs.readFileSync(path.join(agentDir, agents[0]), 'utf-8');
+
+      // Verify OpenCode frontmatter fields
+      expect(agentContent).toMatch(/^---/);
+      expect(agentContent).toMatch(/description:/);
+      expect(agentContent).toMatch(/mode:\s*(primary|subagent)/);
+      expect(agentContent).toMatch(/model:\s*anthropic\//);
+      expect(agentContent).toMatch(/temperature:/);
+      expect(agentContent).toMatch(/maxSteps:/);
+    });
+
+    it('should include tools configuration for agents', () => {
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc`, {
+        encoding: 'utf-8'
+      });
+
+      const agentDir = path.join(testDir, '.opencode', 'agent');
+      const agents = fs.readdirSync(agentDir).filter(f => f.endsWith('.md'));
+
+      // Check at least one agent has tools configuration
+      let hasToolsConfig = false;
+      for (const agent of agents) {
+        const content = fs.readFileSync(path.join(agentDir, agent), 'utf-8');
+        if (content.includes('tools:') && (content.includes('write:') || content.includes('bash:'))) {
+          hasToolsConfig = true;
+          break;
+        }
+      }
+      expect(hasToolsConfig).toBe(true);
+    });
+
+    it('should include permission configuration for implementation agents', () => {
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc`, {
+        encoding: 'utf-8'
+      });
+
+      const agentDir = path.join(testDir, '.opencode', 'agent');
+
+      // Find an implementation-type agent
+      const implementerAgent = path.join(agentDir, 'software-implementer.md');
+      if (fs.existsSync(implementerAgent)) {
+        const content = fs.readFileSync(implementerAgent, 'utf-8');
+        expect(content).toMatch(/permission:/);
+        expect(content).toMatch(/bash:/);
+      }
+    });
+  });
+
+  describe('Command Deployment', () => {
+    it('should deploy commands to .opencode/command/ directory', () => {
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc --deploy-commands`, {
+        encoding: 'utf-8'
+      });
+
+      const commandDir = path.join(testDir, '.opencode', 'command');
+      expect(fs.existsSync(commandDir)).toBe(true);
+
+      const commands = fs.readdirSync(commandDir);
+      expect(commands.length).toBeGreaterThan(0);
+      expect(commands.some(c => c.endsWith('.md'))).toBe(true);
+    });
+
+    it('should transform command frontmatter to OpenCode format', () => {
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc --deploy-commands`, {
+        encoding: 'utf-8'
+      });
+
+      const commandDir = path.join(testDir, '.opencode', 'command');
+      const commands = fs.readdirSync(commandDir).filter(f => f.endsWith('.md'));
+
+      if (commands.length > 0) {
+        const commandContent = fs.readFileSync(path.join(commandDir, commands[0]), 'utf-8');
+
+        // Verify OpenCode command frontmatter
+        expect(commandContent).toMatch(/^---/);
+        expect(commandContent).toMatch(/description:/);
+        expect(commandContent).toMatch(/subtask:\s*true/);
+      }
+    });
+  });
+
+  describe('AGENTS.md Generation', () => {
+    it('should create AGENTS.md when --create-agents-md is specified', () => {
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc --create-agents-md`, {
+        encoding: 'utf-8'
+      });
+
+      const agentsMdPath = path.join(testDir, 'AGENTS.md');
+      expect(fs.existsSync(agentsMdPath)).toBe(true);
+
+      const content = fs.readFileSync(agentsMdPath, 'utf-8');
+      expect(content).toContain('AIWG SDLC Framework');
+      expect(content).toContain('.opencode/agent/');
+    });
+
+    it('should append to existing AGENTS.md without duplicating', () => {
+      // Create initial AGENTS.md
+      const agentsMdPath = path.join(testDir, 'AGENTS.md');
+      fs.writeFileSync(agentsMdPath, '# Project Agents\n\nExisting content.\n');
+
+      // Deploy twice
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc --create-agents-md`, {
+        encoding: 'utf-8'
+      });
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc --create-agents-md`, {
+        encoding: 'utf-8'
+      });
+
+      const content = fs.readFileSync(agentsMdPath, 'utf-8');
+
+      // Should contain AIWG marker comment only once (not duplicated by second deploy)
+      // Note: The template contains "AIWG SDLC Framework" twice (in comment and heading), which is expected
+      const markerMatches = content.match(/<!-- AIWG SDLC Framework Integration -->/g);
+      expect(markerMatches?.length).toBe(1);
+
+      // Should contain the heading only once
+      const headerMatches = content.match(/## AIWG SDLC Framework/g);
+      expect(headerMatches?.length).toBe(1);
+
+      // Should preserve original content
+      expect(content).toContain('Existing content.');
+    });
+  });
+
+  describe('Model Configuration', () => {
+    it('should use OpenCode model format (anthropic/model-name)', () => {
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc`, {
+        encoding: 'utf-8'
+      });
+
+      const agentDir = path.join(testDir, '.opencode', 'agent');
+      const agents = fs.readdirSync(agentDir).filter(f => f.endsWith('.md'));
+
+      for (const agent of agents.slice(0, 5)) {
+        const content = fs.readFileSync(path.join(agentDir, agent), 'utf-8');
+        const modelMatch = content.match(/model:\s*([^\n]+)/);
+        if (modelMatch) {
+          expect(modelMatch[1]).toMatch(/^anthropic\//);
+        }
+      }
+    });
+
+    it('should accept model overrides', () => {
+      execSync(
+        `node ${deployScript} --target ${testDir} --provider opencode --mode sdlc ` +
+        `--reasoning-model anthropic/claude-opus-4-20250514 ` +
+        `--coding-model anthropic/claude-sonnet-4-20250514`,
+        { encoding: 'utf-8' }
+      );
+
+      const agentDir = path.join(testDir, '.opencode', 'agent');
+      const agents = fs.readdirSync(agentDir).filter(f => f.endsWith('.md'));
+
+      // Verify at least one agent uses the override model
+      let foundOverride = false;
+      for (const agent of agents) {
+        const content = fs.readFileSync(path.join(agentDir, agent), 'utf-8');
+        if (content.includes('anthropic/claude-sonnet-4-20250514') ||
+            content.includes('anthropic/claude-opus-4-20250514')) {
+          foundOverride = true;
+          break;
+        }
+      }
+      expect(foundOverride).toBe(true);
+    });
+  });
+
+  describe('Marketing Mode', () => {
+    it('should deploy marketing agents when mode is marketing', () => {
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode marketing`, {
+        encoding: 'utf-8'
+      });
+
+      const agentDir = path.join(testDir, '.opencode', 'agent');
+      expect(fs.existsSync(agentDir)).toBe(true);
+
+      const agents = fs.readdirSync(agentDir);
+      // Marketing agents should include content-related agents
+      expect(agents.some(a =>
+        a.includes('content') ||
+        a.includes('marketing') ||
+        a.includes('campaign') ||
+        a.includes('copywriter')
+      )).toBe(true);
+    });
+  });
+
+  describe('Dry Run', () => {
+    it('should not write files in dry-run mode', () => {
+      execSync(`node ${deployScript} --target ${testDir} --provider opencode --mode sdlc --dry-run`, {
+        encoding: 'utf-8'
+      });
+
+      const agentDir = path.join(testDir, '.opencode', 'agent');
+      expect(fs.existsSync(agentDir)).toBe(false);
+    });
+  });
+});
+
+describe('OpenCode MCP Configuration', () => {
+  let testDir: string;
+  const cliPath = path.resolve(__dirname, '../../src/mcp/cli.mjs');
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiwg-opencode-mcp-test-'));
+  });
+
+  afterEach(() => {
+    if (testDir && fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should generate opencode.json with MCP configuration', () => {
+    // Use cwd option instead of process.chdir (not supported in workers)
+    execSync(`node ${cliPath} install opencode ${testDir}`, {
+      encoding: 'utf-8',
+      cwd: testDir
+    });
+
+    const configPath = path.join(testDir, 'opencode.json');
+    expect(fs.existsSync(configPath)).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(config.mcp).toBeDefined();
+    expect(config.mcp.aiwg).toBeDefined();
+    expect(config.mcp.aiwg.type).toBe('local');
+    expect(config.mcp.aiwg.command).toContain('aiwg');
+  });
+
+  it('should merge with existing opencode.json', () => {
+    const configPath = path.join(testDir, 'opencode.json');
+
+    // Create existing config
+    fs.writeFileSync(configPath, JSON.stringify({
+      model: 'anthropic/claude-sonnet-4-20250514',
+      mcp: {
+        existing: { type: 'local', command: ['existing-server'] }
+      }
+    }, null, 2));
+
+    // Use cwd option instead of process.chdir
+    execSync(`node ${cliPath} install opencode ${testDir}`, {
+      encoding: 'utf-8',
+      cwd: testDir
+    });
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+    // Should preserve existing config
+    expect(config.model).toBe('anthropic/claude-sonnet-4-20250514');
+    expect(config.mcp.existing).toBeDefined();
+
+    // Should add AIWG MCP
+    expect(config.mcp.aiwg).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add OpenCode deployment support for AIWG agents and commands
- Create OpenCode-specific templates (AGENTS.md, agent frontmatter, MCP config)
- Add comprehensive integration test suite (14 tests, all passing)
- Update cross-platform documentation

## Features

**Agent Deployment**
- Deploys to `.opencode/agent/` with OpenCode-specific frontmatter
- Supports mode (primary/subagent), maxSteps, temperature configuration
- Tool permissions configuration (write, edit, bash, webfetch)

**Command Deployment**
- Deploys to `.opencode/command/` with subtask: true format
- Full SDLC command suite available

**MCP Integration**
- `aiwg mcp install opencode` configures opencode.json
- Merges with existing config without duplicating

**Templates**
- AGENTS.md template with AIWG SDLC guidance
- Custom tool template (aiwg-workflow.ts)
- Plugin template for event hooks (aiwg-hooks.ts)
- Theme template
- GitHub Actions workflow for /opencode triggers

## Test plan

- [x] All 2726 tests pass (63 test files)
- [x] OpenCode integration tests (14 tests) verify:
  - Agent deployment to .opencode/agent/
  - Command deployment to .opencode/command/
  - AGENTS.md generation and deduplication
  - MCP configuration in opencode.json
  - Model override support
  - Marketing mode deployment
  - Dry-run mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)