### PR TITLE
feat: improve skill review scores for agent-loop and evals

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/agentic/code/addons/agent-loop/skills/ralph-abort/SKILL.md
+++ b/agentic/code/addons/agent-loop/skills/ralph-abort/SKILL.md
@@ -1,11 +1,17 @@
 ---
-namespace: aiwg
 name: ralph-abort
+description: "Stop a running or paused agent loop and optionally revert all file changes made during iterations. Use when a loop is stuck, producing unwanted changes, or no longer needed."
+namespace: aiwg
 platforms: [all]
-description: Abort a running agent loop and optionally revert changes
+triggers:
+  - ralph abort
+  - stop agent loop
+  - cancel ralph
+  - abort loop
+user-invocable: true
 commandHint:
-  argumentHint: [--keep-changes] [--revert] [--force --interactive --guidance "text"]
-  allowedTools: Read, Write, Bash
+  argumentHint: '[--keep-changes] [--revert] [--force --interactive --guidance "text"]'
+  allowedTools: "Read, Write, Bash"
   model: sonnet
   category: automation
 ---

--- a/agentic/code/addons/agent-loop/skills/ralph-resume/SKILL.md
+++ b/agentic/code/addons/agent-loop/skills/ralph-resume/SKILL.md
@@ -1,11 +1,17 @@
 ---
-namespace: aiwg
 name: ralph-resume
+description: "Resume a paused or interrupted agent loop from its last checkpoint, carrying forward accumulated learnings. Use when a loop timed out, hit its iteration limit, or was interrupted by a network/restart event and still has work to finish."
+namespace: aiwg
 platforms: [all]
-description: Resume an interrupted agent loop from last checkpoint
+triggers:
+  - ralph resume
+  - resume agent loop
+  - continue ralph
+  - resume loop
+user-invocable: true
 commandHint:
-  argumentHint: [--max-iterations N] [--timeout M --interactive --guidance "text"]
-  allowedTools: Task, Read, Write, Bash, Glob, Grep, TodoWrite, Edit
+  argumentHint: '[--max-iterations N] [--timeout M --interactive --guidance "text"]'
+  allowedTools: "Task, Read, Write, Bash, Glob, Grep, TodoWrite, Edit"
   model: opus
   category: automation
   orchestration: true

--- a/agentic/code/addons/agent-loop/skills/ralph-status/SKILL.md
+++ b/agentic/code/addons/agent-loop/skills/ralph-status/SKILL.md
@@ -1,11 +1,17 @@
 ---
-namespace: aiwg
 name: ralph-status
+description: "Display the current or historical status of an agent loop, including iteration progress, completion reports, and failure details. Use when checking whether a loop is active, reviewing past loop results, or diagnosing a stalled iteration."
+namespace: aiwg
 platforms: [all]
-description: Check status of current or previous agent loop
+triggers:
+  - ralph status
+  - loop status
+  - check agent loop
+  - is ralph running
+user-invocable: true
 commandHint:
-  argumentHint: [--verbose] [--latest] [--all --interactive --guidance "text"]
-  allowedTools: Read, Glob, Bash
+  argumentHint: '[--verbose] [--latest] [--all --interactive --guidance "text"]'
+  allowedTools: "Read, Glob, Bash"
   model: haiku
   category: automation
 ---

--- a/agentic/code/addons/agent-loop/skills/ralph/SKILL.md
+++ b/agentic/code/addons/agent-loop/skills/ralph/SKILL.md
@@ -1,13 +1,20 @@
 ---
-namespace: aiwg
 name: al
+description: "Execute an iterative agent task loop that retries until verifiable completion criteria pass. Use when automating multi-step fixes, running tests to green, hitting coverage targets, or any task needing retry-until-done logic."
+namespace: aiwg
 aliases: [ralph, agent-loop]
 deprecated_names: [ralph]
 platforms: [all]
-description: Execute iterative task loop until completion criteria are met - iteration beats perfection
+triggers:
+  - ralph
+  - agent loop
+  - loop until
+  - keep trying until
+  - iterate on
+user-invocable: true
 commandHint:
-  argumentHint: "<task>" --completion "<criteria>" [--max-iterations N] [--timeout M] [--interactive --guidance "text"]
-  allowedTools: Task, Read, Write, Bash, Glob, Grep, TodoWrite, Edit
+  argumentHint: '"<task>" --completion "<criteria>" [--max-iterations N] [--timeout M] [--interactive --guidance "text"]'
+  allowedTools: "Task, Read, Write, Bash, Glob, Grep, TodoWrite, Edit"
   model: opus
   category: automation
   orchestration: true

--- a/agentic/code/addons/aiwg-evals/skills/eval-report/SKILL.md
+++ b/agentic/code/addons/aiwg-evals/skills/eval-report/SKILL.md
@@ -1,7 +1,14 @@
 ---
+name: eval-report
+description: "Generate an aggregate agent quality report from accumulated evaluation results, surfacing per-agent scores, regression trends, and prioritized remediation recommendations. Use when reviewing agent health after eval runs, comparing against a baseline, or preparing a quality dashboard for stakeholders."
 namespace: aiwg
 platforms: [all]
-description: Generate an aggregate agent quality report from evaluation results, showing scores, regressions, and recommendations
+triggers:
+  - eval report
+  - quality report
+  - agent quality
+  - evaluation summary
+user-invocable: true
 ---
 
 # Evaluation Report


### PR DESCRIPTION
Hey @jmagly 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| al (ralph) | 10% | 71% | +61% |
| ralph-status | 10% | 99% | +89% |
| ralph-abort | 10% | 89% | +79% |
| ralph-resume | 10% | 89% | +79% |
| eval-report | 17% | 82% | +65% |

This PR covers your 5 lowest-scoring skill(s) in the repo (out of 400+ in `agentic/code/`). I capped at five to keep the review manageable — the included GitHub Action covers ongoing review for the rest on future PRs.

<details>
<summary>What changed in al (ralph)</summary>

- **Fixed invalid YAML frontmatter** — `argumentHint` and `allowedTools` values contained unquoted special characters (double quotes, brackets) that broke YAML parsing, blocking the entire review evaluation
- **Enhanced description** with concrete action verbs, an explicit "Use when..." clause covering multi-step fixes, test-to-green, and coverage targets
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance

</details>

<details>
<summary>What changed in ralph-status</summary>

- **Fixed invalid YAML frontmatter** — `argumentHint` brackets were parsed as YAML arrays instead of literal text
- **Enhanced description** with specific capabilities (iteration progress, completion reports, failure details) and explicit "Use when..." clause
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance

</details>

<details>
<summary>What changed in ralph-abort</summary>

- **Fixed invalid YAML frontmatter** — same bracket/quote parsing issue as the other ralph-* skills
- **Enhanced description** with explicit "Use when..." clause (stuck loops, unwanted changes, no longer needed)
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance

</details>

<details>
<summary>What changed in ralph-resume</summary>

- **Fixed invalid YAML frontmatter** — same bracket/quote parsing issue
- **Enhanced description** with concrete resume scenarios (timed out, iteration limit, network/restart interruption)
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance

</details>

<details>
<summary>What changed in eval-report</summary>

- **Added missing `name: eval-report`** field — the only validation error blocking the full review evaluation
- **Enhanced description** with specific outputs (per-agent scores, regression trends, remediation recommendations) and explicit "Use when..." clause
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance

</details>

## Tessl Skill Review GitHub Action ✅

I've also included a GitHub Action (`.github/workflows/skill-review.yml`) that automatically reviews any `SKILL.md` changed in future PRs and posts scores as a PR comment.

**What this gives you:**
- 🔍 Automatic `tessl skill review` runs on every PR touching `SKILL.md`
- 💬 One updated PR comment with scores and improvement feedback
- 🔓 **Zero extra accounts** — contributors don't need a Tessl login; only `GITHUB_TOKEN` is used
- ✅ **Non-blocking by default** — feedback-only, no surprise red CI (add `fail-threshold: 70` later if you want a hard gate)
- 📈 Covers future skills incrementally as contributors edit them

## Want automatic AI optimization on every SKILL.md change? 🚀

The action I've added gives you **review scores** on PRs. We also have a more powerful variant — [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) — that can:

- Run **AI-powered optimization suggestions** on every `SKILL.md` PR (requires adding `TESSL_API_TOKEN` as a repo secret)
- Let contributors accept suggested improvements by commenting **`/apply-optimize`**
- Still works in review-only mode with zero secrets

Interested? Tick the box and I'll raise a follow-up PR:

- [ ] **Yes please!** Add the `tesslio/skill-review-and-optimize` action so every SKILL.md PR gets AI optimization suggestions + the `/apply-optimize` flow
- [ ] **No thanks** — the review scores action is enough for now

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏
